### PR TITLE
fix(ci): build once and publish to dev/prod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ on:
 
 env:
   GOLANGCI_LINT_VERSION: latest
-  REGISTRY: asia-east1-docker.pkg.dev/radar-469510/radar
 
 jobs:
   checks:
@@ -37,11 +36,17 @@ jobs:
       - name: Run Tests
         run: go test -race ./...
 
-  build-and-push:
-    name: Build and Push Docker Image
+  build-images:
+    name: Build Docker Images Once
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: checks
+    outputs:
+      any: ${{ steps.build-flags.outputs.any }}
+      radar: ${{ steps.build-flags.outputs.radar }}
+      geoworker: ${{ steps.build-flags.outputs.geoworker }}
+      tag: ${{ steps.set-vars.outputs.TAG }}
+      image_name: ${{ steps.set-vars.outputs.IMAGE_NAME }}
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4
@@ -93,21 +98,7 @@ jobs:
         if: steps.build-flags.outputs.any == 'true'
         uses: docker/setup-buildx-action@v3
 
-      - name: Google Auth
-        if: steps.build-flags.outputs.any == 'true'
-        uses: google-github-actions/auth@v2
-        with:
-          credentials_json: "${{ secrets.GCP_SA_KEY }}"
-
-      - name: Set up Cloud SDK
-        if: steps.build-flags.outputs.any == 'true'
-        uses: google-github-actions/setup-gcloud@v2
-
-      - name: Configure Docker auth for Artifact Registry
-        if: steps.build-flags.outputs.any == 'true'
-        run: gcloud auth configure-docker asia-east1-docker.pkg.dev --quiet
-
-      - name: Build and push Radar image
+      - name: Build Radar image
         if: steps.build-flags.outputs.radar == 'true'
         uses: docker/build-push-action@v5
         with:
@@ -115,13 +106,14 @@ jobs:
           file: ./Dockerfile
           target: radar
           platforms: linux/amd64
-          push: true
+          push: false
+          load: true
           pull: true
           provenance: false
           sbom: false
           tags: |
-            ${{ env.REGISTRY }}/${{ steps.set-vars.outputs.IMAGE_NAME }}/radar:${{ steps.set-vars.outputs.TAG }}
-            ${{ env.REGISTRY }}/${{ steps.set-vars.outputs.IMAGE_NAME }}/radar:latest
+            radar:${{ steps.set-vars.outputs.TAG }}
+            radar:latest
           build-args: |
             VERSION=${{ steps.set-vars.outputs.TAG }}
             BUILT=${{ github.event.head_commit.timestamp }}
@@ -130,7 +122,19 @@ jobs:
           cache-from: type=gha,scope=radar-latest
           cache-to: type=gha,mode=max,scope=radar-latest
 
-      - name: Build and push Geoworker image
+      - name: Save Radar image artifact
+        if: steps.build-flags.outputs.radar == 'true'
+        run: docker save "radar:${{ steps.set-vars.outputs.TAG }}" --output /tmp/radar-image.tar
+
+      - name: Upload Radar image artifact
+        if: steps.build-flags.outputs.radar == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: radar-image
+          path: /tmp/radar-image.tar
+          retention-days: 1
+
+      - name: Build Geoworker image
         if: steps.build-flags.outputs.geoworker == 'true'
         uses: docker/build-push-action@v5
         with:
@@ -138,13 +142,14 @@ jobs:
           file: ./Dockerfile
           target: geoworker
           platforms: linux/amd64
-          push: true
+          push: false
+          load: true
           pull: true
           provenance: false
           sbom: false
           tags: |
-            ${{ env.REGISTRY }}/${{ steps.set-vars.outputs.IMAGE_NAME }}/geoworker:${{ steps.set-vars.outputs.TAG }}
-            ${{ env.REGISTRY }}/${{ steps.set-vars.outputs.IMAGE_NAME }}/geoworker:latest
+            geoworker:${{ steps.set-vars.outputs.TAG }}
+            geoworker:latest
           build-args: |
             VERSION=${{ steps.set-vars.outputs.TAG }}
             BUILT=${{ github.event.head_commit.timestamp }}
@@ -152,3 +157,165 @@ jobs:
             IMAGE_NAME=${{ steps.set-vars.outputs.IMAGE_NAME }}
           cache-from: type=gha,scope=geoworker-latest
           cache-to: type=gha,mode=max,scope=geoworker-latest
+
+      - name: Save Geoworker image artifact
+        if: steps.build-flags.outputs.geoworker == 'true'
+        run: docker save "geoworker:${{ steps.set-vars.outputs.TAG }}" --output /tmp/geoworker-image.tar
+
+      - name: Upload Geoworker image artifact
+        if: steps.build-flags.outputs.geoworker == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: geoworker-image
+          path: /tmp/geoworker-image.tar
+          retention-days: 1
+
+  publish-dev:
+    name: Publish Docker Images (dev)
+    runs-on: ubuntu-latest
+    if: needs.build-images.outputs.any == 'true'
+    needs: build-images
+    env:
+      PROJECT_ID: ${{ vars.GCP_DEV_PROJECT_ID }}
+      REGISTRY: ${{ vars.GCP_DEV_REGISTRY }}
+      TAG: ${{ needs.build-images.outputs.tag }}
+      IMAGE_NAME: ${{ needs.build-images.outputs.image_name }}
+    steps:
+      - name: Validate dev registry configuration
+        env:
+          GCP_SA_KEY: ${{ secrets.GCP_DEV_SA_KEY }}
+        run: |
+          set -euo pipefail
+
+          for required in PROJECT_ID REGISTRY GCP_SA_KEY; do
+            if [ -z "${!required:-}" ]; then
+              echo "::error::Missing required CI configuration: ${required} for dev"
+              exit 1
+            fi
+          done
+
+      - name: Download Radar image artifact
+        if: needs.build-images.outputs.radar == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: radar-image
+          path: /tmp
+
+      - name: Download Geoworker image artifact
+        if: needs.build-images.outputs.geoworker == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: geoworker-image
+          path: /tmp
+
+      - name: Google Auth (dev)
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: "${{ secrets.GCP_DEV_SA_KEY }}"
+
+      - name: Set up Cloud SDK (dev)
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ env.PROJECT_ID }}
+
+      - name: Configure Docker auth for Artifact Registry (dev)
+        run: gcloud auth configure-docker "$(echo "${REGISTRY}" | cut -d/ -f1)" --quiet
+
+      - name: Push Radar image (dev)
+        if: needs.build-images.outputs.radar == 'true'
+        run: |
+          set -euo pipefail
+
+          docker load --input /tmp/radar-image.tar
+          TARGET_BASE="${REGISTRY}/${IMAGE_NAME}/radar"
+          docker tag "radar:${TAG}" "${TARGET_BASE}:${TAG}"
+          docker tag "radar:${TAG}" "${TARGET_BASE}:latest"
+          docker push "${TARGET_BASE}:${TAG}"
+          docker push "${TARGET_BASE}:latest"
+
+      - name: Push Geoworker image (dev)
+        if: needs.build-images.outputs.geoworker == 'true'
+        run: |
+          set -euo pipefail
+
+          docker load --input /tmp/geoworker-image.tar
+          TARGET_BASE="${REGISTRY}/${IMAGE_NAME}/geoworker"
+          docker tag "geoworker:${TAG}" "${TARGET_BASE}:${TAG}"
+          docker tag "geoworker:${TAG}" "${TARGET_BASE}:latest"
+          docker push "${TARGET_BASE}:${TAG}"
+          docker push "${TARGET_BASE}:latest"
+
+  publish-prod:
+    name: Publish Docker Images (prod)
+    runs-on: ubuntu-latest
+    if: needs.build-images.outputs.any == 'true'
+    needs: build-images
+    env:
+      PROJECT_ID: ${{ vars.GCP_PROD_PROJECT_ID }}
+      REGISTRY: ${{ vars.GCP_PROD_REGISTRY }}
+      TAG: ${{ needs.build-images.outputs.tag }}
+      IMAGE_NAME: ${{ needs.build-images.outputs.image_name }}
+    steps:
+      - name: Validate prod registry configuration
+        env:
+          GCP_SA_KEY: ${{ secrets.GCP_PROD_SA_KEY }}
+        run: |
+          set -euo pipefail
+
+          for required in PROJECT_ID REGISTRY GCP_SA_KEY; do
+            if [ -z "${!required:-}" ]; then
+              echo "::error::Missing required CI configuration: ${required} for prod"
+              exit 1
+            fi
+          done
+
+      - name: Download Radar image artifact
+        if: needs.build-images.outputs.radar == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: radar-image
+          path: /tmp
+
+      - name: Download Geoworker image artifact
+        if: needs.build-images.outputs.geoworker == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: geoworker-image
+          path: /tmp
+
+      - name: Google Auth (prod)
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: "${{ secrets.GCP_PROD_SA_KEY }}"
+
+      - name: Set up Cloud SDK (prod)
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ env.PROJECT_ID }}
+
+      - name: Configure Docker auth for Artifact Registry (prod)
+        run: gcloud auth configure-docker "$(echo "${REGISTRY}" | cut -d/ -f1)" --quiet
+
+      - name: Push Radar image (prod)
+        if: needs.build-images.outputs.radar == 'true'
+        run: |
+          set -euo pipefail
+
+          docker load --input /tmp/radar-image.tar
+          TARGET_BASE="${REGISTRY}/${IMAGE_NAME}/radar"
+          docker tag "radar:${TAG}" "${TARGET_BASE}:${TAG}"
+          docker tag "radar:${TAG}" "${TARGET_BASE}:latest"
+          docker push "${TARGET_BASE}:${TAG}"
+          docker push "${TARGET_BASE}:latest"
+
+      - name: Push Geoworker image (prod)
+        if: needs.build-images.outputs.geoworker == 'true'
+        run: |
+          set -euo pipefail
+
+          docker load --input /tmp/geoworker-image.tar
+          TARGET_BASE="${REGISTRY}/${IMAGE_NAME}/geoworker"
+          docker tag "geoworker:${TAG}" "${TARGET_BASE}:${TAG}"
+          docker tag "geoworker:${TAG}" "${TARGET_BASE}:latest"
+          docker push "${TARGET_BASE}:${TAG}"
+          docker push "${TARGET_BASE}:latest"

--- a/.github/workflows/deploy-cloud-run-reusable.yml
+++ b/.github/workflows/deploy-cloud-run-reusable.yml
@@ -1,47 +1,75 @@
-name: Deploy to Cloud Run
+name: Deploy Cloud Run Reusable
 
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
+      environment_name:
+        description: "GitHub environment name"
+        required: true
+        type: string
       target:
         description: "Deploy target"
         required: true
-        type: choice
-        options:
-          - radar
-          - geoworker
+        type: string
       image_ref:
-        description: "Required image tag or commit SHA to deploy."
+        description: "Image tag or commit SHA to deploy"
         required: true
-        default: ""
+        type: string
       run_migration:
         description: "Run database migration before deploy"
         required: false
-        type: boolean
         default: false
-
-env:
-  PROJECT_ID: radar-469510
-  REGION: asia-east1
-  REGISTRY: asia-east1-docker.pkg.dev/radar-469510/radar
+        type: boolean
+      enable_cloudflare_sync:
+        description: "Sync Cloudflare transform rule after deploy"
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   deploy:
+    name: Deploy ${{ inputs.target }} to ${{ inputs.environment_name }}
     runs-on: ubuntu-latest
-
+    environment: ${{ inputs.environment_name }}
     permissions:
-      contents: "read"
-
+      contents: read
+    env:
+      PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+      REGION: ${{ vars.GCP_REGION }}
+      REGISTRY: ${{ vars.GCP_REGISTRY }}
+      ALLOWED_HOST: ${{ vars.HTTP_ALLOWEDHOST }}
+      GCP_SA_EMAIL: ${{ vars.GCP_SA_EMAIL }}
     steps:
+      - name: Validate deployment configuration
+        env:
+          GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
+        run: |
+          set -euo pipefail
+
+          for required in PROJECT_ID REGION REGISTRY ALLOWED_HOST GCP_SA_EMAIL GCP_SA_KEY; do
+            if [ -z "${!required:-}" ]; then
+              echo "::error::Missing required deployment configuration: ${required}"
+              exit 1
+            fi
+          done
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           ref: refs/heads/main
           fetch-depth: 0
 
+      - name: Set up Go version
+        if: ${{ inputs.run_migration }}
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+          cache-dependency-path: go.mod
+
       - name: Google Auth
         id: auth
-        uses: "google-github-actions/auth@v2"
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: "${{ secrets.GCP_SA_KEY }}"
 
@@ -53,12 +81,11 @@ jobs:
       - name: Run Database Migration
         if: ${{ inputs.run_migration }}
         run: |
-          # Install goose
-          go install github.com/pressly/goose/v3/cmd/goose@latest
+          set -euo pipefail
 
-          # Fetch database DSN from Secret Manager and run migration
-          PG_URI=$(gcloud secrets versions access latest --secret="postgres-master-dsn" --project="${{ env.PROJECT_ID }}")
-          $(go env GOPATH)/bin/goose postgres "${PG_URI}" -dir ./database/migration/postgres up
+          go install github.com/pressly/goose/v3/cmd/goose@latest
+          PG_URI=$(gcloud secrets versions access latest --secret="postgres-master-dsn" --project="${PROJECT_ID}")
+          "$(go env GOPATH)/bin/goose" postgres "${PG_URI}" -dir ./database/migration/postgres up
 
       - name: Resolve image reference
         id: image
@@ -66,11 +93,11 @@ jobs:
           set -euo pipefail
 
           OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
-          IMAGE_REF="$(echo "${{ inputs.image_ref }}" | xargs)"
+          IMAGE_REF="$(printf '%s' "${{ inputs.image_ref }}" | xargs)"
           IMAGE_TAG=""
           IMAGE_DIGEST=""
           TAG_SOURCE="manual image ref"
-          TARGET_IMAGE_BASE="${{ env.REGISTRY }}/${OWNER}/${{ inputs.target }}"
+          TARGET_IMAGE_BASE="${REGISTRY}/${OWNER}/${{ inputs.target }}"
 
           if [ -z "${IMAGE_REF}" ]; then
             echo "::error::image_ref is required. Provide a deployable image tag or commit SHA."
@@ -86,16 +113,16 @@ jobs:
 
           IMAGE_NAME="${TARGET_IMAGE_BASE}:${IMAGE_TAG}"
           IMAGE_DIGEST=$(gcloud artifacts docker images describe "${IMAGE_NAME}" \
-            --project="${{ env.PROJECT_ID }}" \
+            --project="${PROJECT_ID}" \
             --format='value(image_summary.fully_qualified_digest)')
 
-          echo "tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
-          echo "name=${IMAGE_NAME}" >> $GITHUB_OUTPUT
-          echo "digest=${IMAGE_DIGEST}" >> $GITHUB_OUTPUT
-          echo "source=${TAG_SOURCE}" >> $GITHUB_OUTPUT
+          echo "tag=${IMAGE_TAG}" >> "${GITHUB_OUTPUT}"
+          echo "name=${IMAGE_NAME}" >> "${GITHUB_OUTPUT}"
+          echo "digest=${IMAGE_DIGEST}" >> "${GITHUB_OUTPUT}"
+          echo "source=${TAG_SOURCE}" >> "${GITHUB_OUTPUT}"
 
+          echo "Deploy environment: ${{ inputs.environment_name }}"
           echo "Deploy target: ${{ inputs.target }}"
-          echo "Workflow ref (ignored for deploy config): ${GITHUB_REF_NAME}"
           echo "Requested image ref: ${IMAGE_REF}"
           echo "Resolved image tag: ${IMAGE_TAG} (${TAG_SOURCE})"
           echo "Resolved image: ${IMAGE_NAME}"
@@ -103,46 +130,59 @@ jobs:
 
       - name: Verify image exists in Artifact Registry
         run: |
+          set -euo pipefail
+
           gcloud artifacts docker images describe "${{ steps.image.outputs.name }}" \
-            --project="${{ env.PROJECT_ID }}" \
+            --project="${PROJECT_ID}" \
             --format='value(image_summary.fully_qualified_digest)'
 
       - name: Prepare service YAML
+        env:
+          CLOUDFLARE_ORIGIN_SECRET: ${{ secrets.CLOUDFLARE_ORIGIN_SECRET }}
         run: |
           set -euo pipefail
 
-          if [ "${{ inputs.target }}" = "radar" ] && [ -z "${{ secrets.CLOUDFLARE_ORIGIN_SECRET }}" ]; then
-            echo "::error::Missing required GitHub secret: CLOUDFLARE_ORIGIN_SECRET"
-            exit 1
+          kubectl kustomize "deploy/cloud-run/overlays/${{ inputs.environment_name }}/${{ inputs.target }}" > /tmp/service.yaml
+
+          IMAGE_NAME_ESCAPED=$(printf '%s' "${{ steps.image.outputs.name }}" | sed -e 's/[\\/&]/\\&/g')
+          SERVICE_ACCOUNT_ESCAPED=$(printf '%s' "${GCP_SA_EMAIL}" | sed -e 's/[\\/&]/\\&/g')
+          PROJECT_ID_ESCAPED=$(printf '%s' "${PROJECT_ID}" | sed -e 's/[\\/&]/\\&/g')
+          ALLOWED_HOST_ESCAPED=$(printf '%s' "${ALLOWED_HOST}" | sed -e 's/[\\/&]/\\&/g')
+
+          sed -i "s|IMAGE_PLACEHOLDER|${IMAGE_NAME_ESCAPED}|g" /tmp/service.yaml
+          sed -i "s|SERVICE_ACCOUNT_PLACEHOLDER|${SERVICE_ACCOUNT_ESCAPED}|g" /tmp/service.yaml
+          sed -i "s|PROJECT_ID_PLACEHOLDER|${PROJECT_ID_ESCAPED}|g" /tmp/service.yaml
+          sed -i "s|HTTP_ALLOWEDHOST_PLACEHOLDER|${ALLOWED_HOST_ESCAPED}|g" /tmp/service.yaml
+
+          if grep -q "HTTP_CLOUDFLARESECRET_PLACEHOLDER" /tmp/service.yaml; then
+            if [ -z "${CLOUDFLARE_ORIGIN_SECRET:-}" ]; then
+              echo "::error::Missing required environment secret: CLOUDFLARE_ORIGIN_SECRET"
+              exit 1
+            fi
+
+            CLOUDFLARE_SECRET_ESCAPED=$(printf '%s' "${CLOUDFLARE_ORIGIN_SECRET}" | sed -e 's/[\\/&]/\\&/g')
+            sed -i "s|HTTP_CLOUDFLARESECRET_PLACEHOLDER|${CLOUDFLARE_SECRET_ESCAPED}|g" /tmp/service.yaml
           fi
 
-          # Build final YAML using kubectl's built-in kustomize
-          kubectl kustomize deploy/cloud-run/overlays/${{ inputs.target }} > /tmp/service.yaml
-          # Replace image placeholder
-          sed -i "s|IMAGE_PLACEHOLDER|${{ steps.image.outputs.name }}|g" /tmp/service.yaml
-          # Replace service account placeholder
-          sed -i "s|SERVICE_ACCOUNT_PLACEHOLDER|${{ secrets.GCP_SA_EMAIL }}|g" /tmp/service.yaml
-          # Replace Cloudflare origin secret placeholder from GitHub Secret
-          CLOUDFLARE_SECRET_ESCAPED=$(printf '%s' "${{ secrets.CLOUDFLARE_ORIGIN_SECRET }}" | sed -e 's/[\\/&]/\\&/g')
-          sed -i "s|HTTP_CLOUDFLARESECRET_PLACEHOLDER|${CLOUDFLARE_SECRET_ESCAPED}|g" /tmp/service.yaml
       - name: Deploy to Cloud Run
         id: deploy
         run: |
-          gcloud run services replace /tmp/service.yaml \
-            --project=${{ env.PROJECT_ID }} \
-            --region=${{ env.REGION }}
+          set -euo pipefail
 
-          # radar should allow unauthenticated access
-          if [ "${{ inputs.target }}" = "radar" ]; then
-            gcloud run services add-iam-policy-binding ${{ inputs.target }} \
-              --project=${{ env.PROJECT_ID }} \
-              --region=${{ env.REGION }} \
+          gcloud run services replace /tmp/service.yaml \
+            --project="${PROJECT_ID}" \
+            --region="${REGION}"
+
+          if [ "${{ inputs.environment_name }}" = "prod" ] && [ "${{ inputs.target }}" = "radar" ]; then
+            gcloud run services add-iam-policy-binding "${{ inputs.target }}" \
+              --project="${PROJECT_ID}" \
+              --region="${REGION}" \
               --member="allUsers" \
               --role="roles/run.invoker"
           fi
 
       - name: Sync Cloudflare Transform Rule Header
-        if: ${{ inputs.target == 'radar' }}
+        if: ${{ inputs.enable_cloudflare_sync && inputs.target == 'radar' }}
         env:
           CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CF_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
@@ -153,8 +193,8 @@ jobs:
           set -euo pipefail
 
           for required in CF_API_TOKEN CF_ZONE_ID CF_RULE_ID CF_ORIGIN_SECRET; do
-            if [ -z "${!required}" ]; then
-              echo "::error::Missing required GitHub secret: ${required}"
+            if [ -z "${!required:-}" ]; then
+              echo "::error::Missing required environment secret: ${required}"
               exit 1
             fi
           done
@@ -203,7 +243,9 @@ jobs:
 
       - name: Show Output
         run: |
-          gcloud run services describe ${{ inputs.target }} \
-            --project=${{ env.PROJECT_ID }} \
-            --region=${{ env.REGION }} \
+          set -euo pipefail
+
+          gcloud run services describe "${{ inputs.target }}" \
+            --project="${PROJECT_ID}" \
+            --region="${REGION}" \
             --format='value(status.url)'

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,32 @@
+name: Deploy Dev
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Deploy target"
+        required: true
+        type: choice
+        options:
+          - radar
+          - geoworker
+      image_ref:
+        description: "Required image tag or commit SHA to deploy."
+        required: true
+        default: ""
+      run_migration:
+        description: "Run database migration before deploy"
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/deploy-cloud-run-reusable.yml
+    with:
+      environment_name: dev
+      target: ${{ inputs.target }}
+      image_ref: ${{ inputs.image_ref }}
+      run_migration: ${{ inputs.run_migration }}
+      enable_cloudflare_sync: false
+    secrets: inherit

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,32 @@
+name: Deploy Prod
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Deploy target"
+        required: true
+        type: choice
+        options:
+          - radar
+          - geoworker
+      image_ref:
+        description: "Required image tag or commit SHA to deploy."
+        required: true
+        default: ""
+      run_migration:
+        description: "Run database migration before deploy"
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/deploy-cloud-run-reusable.yml
+    with:
+      environment_name: prod
+      target: ${{ inputs.target }}
+      image_ref: ${{ inputs.image_ref }}
+      run_migration: ${{ inputs.run_migration }}
+      enable_cloudflare_sync: true
+    secrets: inherit

--- a/deploy/cloud-run/base/service-template.yaml
+++ b/deploy/cloud-run/base/service-template.yaml
@@ -12,12 +12,12 @@ spec:
         autoscaling.knative.dev/maxScale: "10"
         run.googleapis.com/execution-environment: gen2
     spec:
-      serviceAccountName: SERVICE_ACCOUNT_PLACEHOLDER
+      serviceAccountName: "SERVICE_ACCOUNT_PLACEHOLDER"
       containerConcurrency: 80
       timeoutSeconds: 60
       containers:
         - name: app
-          image: IMAGE_PLACEHOLDER
+          image: "IMAGE_PLACEHOLDER"
           startupProbe:
             httpGet:
               path: /health
@@ -84,7 +84,7 @@ spec:
 
             # ========== Firebase Configuration ==========
             - name: FIREBASE_PROJECTID
-              value: PROJECT_ID_PLACEHOLDER
+              value: "PROJECT_ID_PLACEHOLDER"
             - name: FIREBASE_CREDENTIALSPATH
               value: /secrets/firebase/service-account.json
 
@@ -92,7 +92,7 @@ spec:
             - name: PUBSUB_PROVIDER
               value: "google"
             - name: PUBSUB_PROJECTID
-              value: PROJECT_ID_PLACEHOLDER
+              value: "PROJECT_ID_PLACEHOLDER"
             - name: PUBSUB_TOPICID
               valueFrom:
                 secretKeyRef:

--- a/deploy/cloud-run/base/service-template.yaml
+++ b/deploy/cloud-run/base/service-template.yaml
@@ -16,7 +16,8 @@ spec:
       containerConcurrency: 80
       timeoutSeconds: 60
       containers:
-        - image: IMAGE_PLACEHOLDER
+        - name: app
+          image: IMAGE_PLACEHOLDER
           startupProbe:
             httpGet:
               path: /health
@@ -42,9 +43,7 @@ spec:
             - name: HTTP_MAXREQUESTBODYSIZE
               value: "100KB"
             - name: HTTP_ALLOWEDHOST
-              value: "api.whereisvendor.com"
-            - name: HTTP_CLOUDFLARESECRET
-              value: "HTTP_CLOUDFLARESECRET_PLACEHOLDER"
+              value: "HTTP_ALLOWEDHOST_PLACEHOLDER"
             # Cloud Run should emit structured JSON logs for queryability.
             - name: ENV_LOG_PRETTY
               value: "false"
@@ -85,7 +84,7 @@ spec:
 
             # ========== Firebase Configuration ==========
             - name: FIREBASE_PROJECTID
-              value: radar-469510
+              value: PROJECT_ID_PLACEHOLDER
             - name: FIREBASE_CREDENTIALSPATH
               value: /secrets/firebase/service-account.json
 
@@ -93,7 +92,7 @@ spec:
             - name: PUBSUB_PROVIDER
               value: "google"
             - name: PUBSUB_PROJECTID
-              value: radar-469510
+              value: PROJECT_ID_PLACEHOLDER
             - name: PUBSUB_TOPICID
               valueFrom:
                 secretKeyRef:

--- a/deploy/cloud-run/overlays/dev/geoworker/kustomization.yaml
+++ b/deploy/cloud-run/overlays/dev/geoworker/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../shared/geoworker

--- a/deploy/cloud-run/overlays/dev/geoworker/kustomization.yaml
+++ b/deploy/cloud-run/overlays/dev/geoworker/kustomization.yaml
@@ -25,4 +25,3 @@ patches:
                 resources:
                   limits:
                     memory: 128Mi
-                    cpu: "1"

--- a/deploy/cloud-run/overlays/dev/geoworker/kustomization.yaml
+++ b/deploy/cloud-run/overlays/dev/geoworker/kustomization.yaml
@@ -27,4 +27,4 @@ patches:
                 resources:
                   limits:
                     memory: 128Mi
-                    cpu: "0.08"
+                    cpu: "1"

--- a/deploy/cloud-run/overlays/dev/geoworker/kustomization.yaml
+++ b/deploy/cloud-run/overlays/dev/geoworker/kustomization.yaml
@@ -3,3 +3,28 @@ kind: Kustomization
 
 resources:
   - ../../shared/geoworker
+
+patches:
+  - target:
+      kind: Service
+      name: geoworker
+    patch: |-
+      apiVersion: serving.knative.dev/v1
+      kind: Service
+      metadata:
+        name: geoworker
+      spec:
+        template:
+          metadata:
+            annotations:
+              autoscaling.knative.dev/maxScale: "1"
+              run.googleapis.com/execution-environment: gen1
+          spec:
+            containerConcurrency: 1
+            timeoutSeconds: 1
+            containers:
+              - name: app
+                resources:
+                  limits:
+                    memory: 128Mi
+                    cpu: "0.08"

--- a/deploy/cloud-run/overlays/dev/geoworker/kustomization.yaml
+++ b/deploy/cloud-run/overlays/dev/geoworker/kustomization.yaml
@@ -18,10 +18,8 @@ patches:
           metadata:
             annotations:
               autoscaling.knative.dev/maxScale: "1"
-              run.googleapis.com/execution-environment: gen1
           spec:
             containerConcurrency: 1
-            timeoutSeconds: 1
             containers:
               - name: app
                 resources:

--- a/deploy/cloud-run/overlays/dev/radar/kustomization.yaml
+++ b/deploy/cloud-run/overlays/dev/radar/kustomization.yaml
@@ -28,10 +28,8 @@ patches:
           metadata:
             annotations:
               autoscaling.knative.dev/maxScale: "1"
-              run.googleapis.com/execution-environment: gen1
           spec:
             containerConcurrency: 1
-            timeoutSeconds: 1
             containers:
               - name: app
                 resources:

--- a/deploy/cloud-run/overlays/dev/radar/kustomization.yaml
+++ b/deploy/cloud-run/overlays/dev/radar/kustomization.yaml
@@ -37,4 +37,4 @@ patches:
                 resources:
                   limits:
                     memory: 128Mi
-                    cpu: "0.08"
+                    cpu: "1"

--- a/deploy/cloud-run/overlays/dev/radar/kustomization.yaml
+++ b/deploy/cloud-run/overlays/dev/radar/kustomization.yaml
@@ -9,20 +9,13 @@ patches:
       kind: Service
       name: radar
     patch: |-
-      - op: replace
-        path: /metadata/annotations/run.googleapis.com~1ingress
-        value: internal
-      - op: add
-        path: /metadata/annotations/run.googleapis.com~1invoker-iam-disabled
-        value: "false"
-  - target:
-      kind: Service
-      name: radar
-    patch: |-
       apiVersion: serving.knative.dev/v1
       kind: Service
       metadata:
         name: radar
+        annotations:
+          run.googleapis.com/ingress: internal
+          run.googleapis.com/invoker-iam-disabled: "false"
       spec:
         template:
           metadata:
@@ -35,4 +28,3 @@ patches:
                 resources:
                   limits:
                     memory: 128Mi
-                    cpu: "1"

--- a/deploy/cloud-run/overlays/dev/radar/kustomization.yaml
+++ b/deploy/cloud-run/overlays/dev/radar/kustomization.yaml
@@ -15,3 +15,26 @@ patches:
       - op: add
         path: /metadata/annotations/run.googleapis.com~1invoker-iam-disabled
         value: "false"
+  - target:
+      kind: Service
+      name: radar
+    patch: |-
+      apiVersion: serving.knative.dev/v1
+      kind: Service
+      metadata:
+        name: radar
+      spec:
+        template:
+          metadata:
+            annotations:
+              autoscaling.knative.dev/maxScale: "1"
+              run.googleapis.com/execution-environment: gen1
+          spec:
+            containerConcurrency: 1
+            timeoutSeconds: 1
+            containers:
+              - name: app
+                resources:
+                  limits:
+                    memory: 128Mi
+                    cpu: "0.08"

--- a/deploy/cloud-run/overlays/dev/radar/kustomization.yaml
+++ b/deploy/cloud-run/overlays/dev/radar/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../shared/radar
+
+patches:
+  - target:
+      kind: Service
+      name: radar
+    patch: |-
+      - op: replace
+        path: /metadata/annotations/run.googleapis.com~1ingress
+        value: internal
+      - op: add
+        path: /metadata/annotations/run.googleapis.com~1invoker-iam-disabled
+        value: "false"

--- a/deploy/cloud-run/overlays/prod/geoworker/kustomization.yaml
+++ b/deploy/cloud-run/overlays/prod/geoworker/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../shared/geoworker

--- a/deploy/cloud-run/overlays/prod/radar/kustomization.yaml
+++ b/deploy/cloud-run/overlays/prod/radar/kustomization.yaml
@@ -1,0 +1,33 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../shared/radar
+
+patches:
+  - target:
+      kind: Service
+      name: radar
+    patch: |-
+      - op: replace
+        path: /metadata/annotations/run.googleapis.com~1ingress
+        value: all
+      - op: add
+        path: /metadata/annotations/run.googleapis.com~1invoker-iam-disabled
+        value: "true"
+  - target:
+      kind: Service
+      name: radar
+    patch: |-
+      apiVersion: serving.knative.dev/v1
+      kind: Service
+      metadata:
+        name: radar
+      spec:
+        template:
+          spec:
+            containers:
+              - name: app
+                env:
+                  - name: HTTP_CLOUDFLARESECRET
+                    value: HTTP_CLOUDFLARESECRET_PLACEHOLDER

--- a/deploy/cloud-run/overlays/prod/radar/kustomization.yaml
+++ b/deploy/cloud-run/overlays/prod/radar/kustomization.yaml
@@ -9,20 +9,13 @@ patches:
       kind: Service
       name: radar
     patch: |-
-      - op: replace
-        path: /metadata/annotations/run.googleapis.com~1ingress
-        value: all
-      - op: add
-        path: /metadata/annotations/run.googleapis.com~1invoker-iam-disabled
-        value: "true"
-  - target:
-      kind: Service
-      name: radar
-    patch: |-
       apiVersion: serving.knative.dev/v1
       kind: Service
       metadata:
         name: radar
+        annotations:
+          run.googleapis.com/ingress: all
+          run.googleapis.com/invoker-iam-disabled: "true"
       spec:
         template:
           spec:
@@ -30,4 +23,4 @@ patches:
               - name: app
                 env:
                   - name: HTTP_CLOUDFLARESECRET
-                    value: HTTP_CLOUDFLARESECRET_PLACEHOLDER
+                    value: "HTTP_CLOUDFLARESECRET_PLACEHOLDER"

--- a/deploy/cloud-run/overlays/prod/radar/kustomization.yaml
+++ b/deploy/cloud-run/overlays/prod/radar/kustomization.yaml
@@ -14,7 +14,6 @@ patches:
       metadata:
         name: radar
         annotations:
-          run.googleapis.com/ingress: all
           run.googleapis.com/invoker-iam-disabled: "true"
       spec:
         template:

--- a/deploy/cloud-run/overlays/shared/geoworker/kustomization.yaml
+++ b/deploy/cloud-run/overlays/shared/geoworker/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - ../../base
+  - ../../../base
 
 patches:
   - target:

--- a/deploy/cloud-run/overlays/shared/radar/kustomization.yaml
+++ b/deploy/cloud-run/overlays/shared/radar/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - ../../base
+  - ../../../base
 
 patches:
   - target:
@@ -12,12 +12,6 @@ patches:
       - op: replace
         path: /metadata/name
         value: radar
-      - op: replace
-        path: /metadata/annotations/run.googleapis.com~1ingress
-        value: all
-      - op: add
-        path: /metadata/annotations/run.googleapis.com~1invoker-iam-disabled
-        value: "true"
       - op: replace
         path: /spec/template/metadata/annotations/autoscaling.knative.dev~1maxScale
         value: "10"

--- a/deploy/cloud-run/overlays/shared/radar/kustomization.yaml
+++ b/deploy/cloud-run/overlays/shared/radar/kustomization.yaml
@@ -13,9 +13,6 @@ patches:
         path: /metadata/name
         value: radar
       - op: replace
-        path: /spec/template/metadata/annotations/autoscaling.knative.dev~1maxScale
-        value: "10"
-      - op: replace
         path: /spec/template/spec/containerConcurrency
         value: 500
       - op: replace


### PR DESCRIPTION
## Background
This PR refactors CI and Cloud Run deployment configuration to avoid duplicate image builds, reduce cache overhead, and lower overlay maintenance cost.

## Changes
- Build images once, then publish to both dev and prod registries.
- Consolidate cache scopes to `radar-latest` and `geoworker-latest`.
- Replace matrix-based dynamic secret/var lookups with explicit `GCP_DEV_*` and `GCP_PROD_*` repo-level keys.
- Harden `image_ref` trimming by using `printf '%s'` before `xargs`.
- Introduce shared Cloud Run overlays and keep only environment-specific differences in dev/prod overlays.
- For prod radar, use a single strategic merge patch for ingress, invoker IAM flag, and `HTTP_CLOUDFLARESECRET`.
- Quote placeholder values in the base service template to avoid YAML type-casting edge cases.

## Scope
- CI workflows and Cloud Run kustomize configuration only.
- No application runtime logic changes.

## Validation
1. Trigger CI on `main` and confirm images are built once and published separately to dev/prod.
2. Compare dev/prod image digests for the same tag.
3. Run deploy workflows with whitespace around `image_ref` and verify parsing is correct.
4. Run `kubectl kustomize deploy/cloud-run/overlays/prod/radar` and verify `HTTP_CLOUDFLARESECRET` exists in env.
