### PR TITLE
fix(deploy): preserve cloud run image

### DIFF
--- a/deploy/cloud-run/overlays/dev/geoworker/kustomization.yaml
+++ b/deploy/cloud-run/overlays/dev/geoworker/kustomization.yaml
@@ -9,19 +9,12 @@ patches:
       kind: Service
       name: geoworker
     patch: |-
-      apiVersion: serving.knative.dev/v1
-      kind: Service
-      metadata:
-        name: geoworker
-      spec:
-        template:
-          metadata:
-            annotations:
-              autoscaling.knative.dev/maxScale: "1"
-          spec:
-            containerConcurrency: 1
-            containers:
-              - name: app
-                resources:
-                  limits:
-                    memory: 128Mi
+      - op: replace
+        path: /spec/template/metadata/annotations/autoscaling.knative.dev~1maxScale
+        value: "1"
+      - op: replace
+        path: /spec/template/spec/containerConcurrency
+        value: 1
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/limits/memory
+        value: 128Mi

--- a/deploy/cloud-run/overlays/dev/radar/kustomization.yaml
+++ b/deploy/cloud-run/overlays/dev/radar/kustomization.yaml
@@ -9,22 +9,18 @@ patches:
       kind: Service
       name: radar
     patch: |-
-      apiVersion: serving.knative.dev/v1
-      kind: Service
-      metadata:
-        name: radar
-        annotations:
-          run.googleapis.com/ingress: internal
-          run.googleapis.com/invoker-iam-disabled: "false"
-      spec:
-        template:
-          metadata:
-            annotations:
-              autoscaling.knative.dev/maxScale: "1"
-          spec:
-            containerConcurrency: 1
-            containers:
-              - name: app
-                resources:
-                  limits:
-                    memory: 128Mi
+      - op: replace
+        path: /metadata/annotations/run.googleapis.com~1ingress
+        value: internal
+      - op: add
+        path: /metadata/annotations/run.googleapis.com~1invoker-iam-disabled
+        value: "false"
+      - op: replace
+        path: /spec/template/metadata/annotations/autoscaling.knative.dev~1maxScale
+        value: "1"
+      - op: replace
+        path: /spec/template/spec/containerConcurrency
+        value: 1
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/limits/memory
+        value: 128Mi

--- a/deploy/cloud-run/overlays/prod/radar/kustomization.yaml
+++ b/deploy/cloud-run/overlays/prod/radar/kustomization.yaml
@@ -9,17 +9,11 @@ patches:
       kind: Service
       name: radar
     patch: |-
-      apiVersion: serving.knative.dev/v1
-      kind: Service
-      metadata:
-        name: radar
-        annotations:
-          run.googleapis.com/invoker-iam-disabled: "true"
-      spec:
-        template:
-          spec:
-            containers:
-              - name: app
-                env:
-                  - name: HTTP_CLOUDFLARESECRET
-                    value: "HTTP_CLOUDFLARESECRET_PLACEHOLDER"
+      - op: add
+        path: /metadata/annotations/run.googleapis.com~1invoker-iam-disabled
+        value: "true"
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: HTTP_CLOUDFLARESECRET
+          value: HTTP_CLOUDFLARESECRET_PLACEHOLDER


### PR DESCRIPTION
- convert Cloud Run overlay patches to JSON patch operations
- avoid replacing the full container spec during kustomize
- preserve image, env, ports, probes, and volume mounts in dev and prod deploys