### PR TITLE
fix(deploy): raise gen2 memory minimum

### DIFF
--- a/deploy/cloud-run/overlays/dev/geoworker/kustomization.yaml
+++ b/deploy/cloud-run/overlays/dev/geoworker/kustomization.yaml
@@ -17,4 +17,4 @@ patches:
         value: 1
       - op: replace
         path: /spec/template/spec/containers/0/resources/limits/memory
-        value: 128Mi
+        value: 512Mi

--- a/deploy/cloud-run/overlays/dev/radar/kustomization.yaml
+++ b/deploy/cloud-run/overlays/dev/radar/kustomization.yaml
@@ -23,4 +23,4 @@ patches:
         value: 1
       - op: replace
         path: /spec/template/spec/containers/0/resources/limits/memory
-        value: 128Mi
+        value: 512Mi


### PR DESCRIPTION
- increase dev Cloud Run memory limits to satisfy gen2 minimum
- keep dev overlays compatible with Cloud Run validation