### PR TITLE
fix(deploy): align cloud run scaling

### DIFF
--- a/deploy/cloud-run/base/service-template.yaml
+++ b/deploy/cloud-run/base/service-template.yaml
@@ -30,7 +30,7 @@ spec:
               containerPort: 8080
           resources:
             limits:
-              memory: 256Mi
+              memory: 512Mi
               cpu: "1"
           volumeMounts:
             - name: firebase-service-account

--- a/deploy/cloud-run/overlays/dev/geoworker/kustomization.yaml
+++ b/deploy/cloud-run/overlays/dev/geoworker/kustomization.yaml
@@ -10,6 +10,12 @@ patches:
       name: geoworker
     patch: |-
       - op: replace
+        path: /metadata/annotations/run.googleapis.com~1minScale
+        value: "0"
+      - op: replace
+        path: /metadata/annotations/run.googleapis.com~1maxScale
+        value: "1"
+      - op: replace
         path: /spec/template/metadata/annotations/autoscaling.knative.dev~1maxScale
         value: "1"
       - op: replace

--- a/deploy/cloud-run/overlays/dev/radar/kustomization.yaml
+++ b/deploy/cloud-run/overlays/dev/radar/kustomization.yaml
@@ -11,10 +11,16 @@ patches:
     patch: |-
       - op: replace
         path: /metadata/annotations/run.googleapis.com~1ingress
-        value: internal
+        value: all
       - op: add
         path: /metadata/annotations/run.googleapis.com~1invoker-iam-disabled
-        value: "false"
+        value: "true"
+      - op: replace
+        path: /metadata/annotations/run.googleapis.com~1minScale
+        value: "0"
+      - op: replace
+        path: /metadata/annotations/run.googleapis.com~1maxScale
+        value: "1"
       - op: replace
         path: /spec/template/metadata/annotations/autoscaling.knative.dev~1maxScale
         value: "1"

--- a/deploy/cloud-run/overlays/shared/geoworker/kustomization.yaml
+++ b/deploy/cloud-run/overlays/shared/geoworker/kustomization.yaml
@@ -12,6 +12,12 @@ patches:
       - op: replace
         path: /metadata/name
         value: geoworker
+      - op: add
+        path: /metadata/annotations/run.googleapis.com~1minScale
+        value: "0"
+      - op: add
+        path: /metadata/annotations/run.googleapis.com~1maxScale
+        value: "5"
       - op: replace
         path: /metadata/annotations/run.googleapis.com~1ingress
         value: internal

--- a/deploy/cloud-run/overlays/shared/radar/kustomization.yaml
+++ b/deploy/cloud-run/overlays/shared/radar/kustomization.yaml
@@ -12,6 +12,12 @@ patches:
       - op: replace
         path: /metadata/name
         value: radar
+      - op: add
+        path: /metadata/annotations/run.googleapis.com~1minScale
+        value: "0"
+      - op: add
+        path: /metadata/annotations/run.googleapis.com~1maxScale
+        value: "10"
       - op: replace
         path: /spec/template/spec/containerConcurrency
         value: 500


### PR DESCRIPTION
- add service-level min/max scaling annotations for Cloud Run
- keep dev radar and geoworker resource scheduling at 0-1
- make compiled manifests match Cloud Run console autoscaling