### PR TITLE
docs: update notification architecture notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,11 +130,11 @@ mockery
 
 ## 🤔 How It Works
 
-1. **Vendor Pings Location**: A food truck owner sends a `POST` request with their `vendorId` and current coordinates (`latitude`, `longitude`) to the `/api/vendors/location` endpoint.
-2. **Location is Stored**: The Go service updates the vendor's location in the PostGIS database. The location is stored as a `GEOGRAPHY` or `GEOMETRY` type using a Go database driver.
-3. **Proximity Check Job**: A background Goroutine or scheduled job runs periodically (e.g., every minute).
-4. **Geospatial Query**: The worker queries the database, asking: "For each user, are there any vendors within their specified notification radius?" This is efficiently handled by the PostGIS `ST_DWithin` function.
-5. **Notification Sent**: If a match is found, the service triggers a push notification via FCM to the relevant user's device, letting them know a favorite food truck is nearby.
+1. **Merchant Publishes Location**: A food truck owner sends a `POST` request with their current coordinates and location details to the notification endpoint.
+2. **Subscriber Pre-filtering**: The API server queries PostGIS (`ST_DWithin`) to find subscribed users within range, keeping the routing workload bounded.
+3. **Event Published**: The filtered subscriber list is published as an event to Google Cloud Pub/Sub (or a local HTTP endpoint in development).
+4. **Geo Worker Processes Event**: A separate Geo Worker service receives the event, calculates road network distances using the PMTiles-based routing engine, and filters out unreachable users (e.g., across the Taiwan Strait).
+5. **Notification Sent**: The Geo Worker sends push notifications via FCM to eligible users, letting them know a favorite food truck is nearby.
 
 ## 🗺️ Routing Engine
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ NomNom-Radar is a real-time notification backend service. It utilizes PostgreSQL
 * **Real-time Vendor Tracking**: Allows food truck owners to update their location instantly via a simple API endpoint.
 * **Dynamic Geofencing**: Users can define a custom notification radius (e.g., 500 meters, 1 km).
 * **High-Performance Geospatial Queries**: Leverages the power of PostGIS (`ST_DWithin`) for efficient, low-latency proximity checks.
-* **Road Network Routing**: Uses Contraction Hierarchies (CH) algorithm for accurate road network distance and ETA calculations, detecting unreachable locations (e.g., Taiwan ↔ Penghu islands).
+* **Route-Aware Distance Filtering**: Uses a PMTiles-based routing engine for route-aware distance checks, with straight-line fallback when route data is unavailable.
 * **Push Notification System**: Integrates with services like Firebase Cloud Messaging (FCM) to deliver instant alerts to users' devices.
 * **Open & Share-Alike**: Licensed under AGPL-3.0 to encourage community contribution while protecting the project from being used in proprietary, closed-source commercial services.
 
@@ -22,7 +22,7 @@ NomNom-Radar is a real-time notification backend service. It utilizes PostgreSQL
 * **Backend**: **Go** with **Echo** framework
 * **Database**: PostgreSQL + PostGIS extension for geospatial data
 * **Database Driver/ORM**: **GORM**
-* **Routing Engine**: Custom CH implementation with [LdDl/ch](https://github.com/LdDl/ch) + Grid-based spatial index
+* **Routing Engine**: PMTiles-based routing with MVT parsing, local pathfinding, and Haversine fallback
 * **Push Notifications**: Firebase Cloud Messaging (FCM)
 * **Containerization**: Docker & Docker Compose
 
@@ -133,7 +133,7 @@ mockery
 1. **Merchant Publishes Location**: A food truck owner sends a `POST` request with their current coordinates and location details to the notification endpoint.
 2. **Subscriber Pre-filtering**: The API server queries PostGIS (`ST_DWithin`) to find subscribed users within range, keeping the routing workload bounded.
 3. **Event Published**: The filtered subscriber list is published as an event to Google Cloud Pub/Sub (or a local HTTP endpoint in development).
-4. **Geo Worker Processes Event**: A separate Geo Worker service receives the event, calculates road network distances using the PMTiles-based routing engine, and filters out unreachable users (e.g., across the Taiwan Strait).
+4. **Geo Worker Processes Event**: A separate Geo Worker service receives the event, calculates route-aware distances using the PMTiles-based routing engine, and falls back to straight-line distance when route data is unavailable.
 5. **Notification Sent**: The Geo Worker sends push notifications via FCM to eligible users, letting them know a favorite food truck is nearby.
 
 ## 🗺️ Routing Engine
@@ -143,7 +143,7 @@ NomNom-Radar includes a high-performance road network routing engine for accurat
 ### Features
 
 * **Road Network Distance**: Calculate real driving distances instead of straight-line (Haversine) approximations
-* **Island Detection**: Correctly identifies unreachable locations (e.g., Taiwan ↔ Penghu, Kinmen islands)
+* **Route-Aware Filtering**: Uses PMTiles-based routing when available and falls back to straight-line distance when route data is unavailable
 * **One-to-Many Queries**: Efficiently calculate distances from one merchant to thousands of users
 * **GPS Snap Validation**: Detects GPS drift by validating snap distance to road network
 * **Haversine Fallback**: Gracefully degrades to straight-line distance when routing data is unavailable

--- a/docs/product-priority-notes.md
+++ b/docs/product-priority-notes.md
@@ -61,7 +61,7 @@ Scheduled Notification current state:
 
 | # | Item | Rationale |
 |---|------|-----------|
-| 12 | Subscription Pause / Resume vs Unsubscribe | Worth doing to prevent subscriber loss from users who just want to mute temporarily. Semantics need to be defined first. Notification radius remains intentionally fixed to the default value for now. |
+| 12 | Subscription Pause / Resume vs Unsubscribe | Worth doing to prevent subscriber loss from users who just want to mute temporarily. Semantics need to be defined first. The backend supports custom notification radius values, but the current product flow intentionally keeps the radius fixed to the default value for now. |
 | 13 | Merchant Onboarding Setup Checklist | Most valuable after Tier 2 features are in place, otherwise the checklist has little content. |
 | 14 | Google Account Linking / Unlinking | Edge case. Most users choose their login method at registration time. |
 

--- a/docs/product-priority-notes.md
+++ b/docs/product-priority-notes.md
@@ -1,0 +1,76 @@
+# Product Priority Notes
+
+This document records the current product decisions, deferred feature priorities, and implementation order for NomNom-Radar.
+
+## Confirmed Product Assumptions
+
+- The product is a notification service for mobile merchants such as food trucks.
+- Merchant discovery is not a current P0 requirement.
+- The current intended acquisition path is:
+  - user visits the merchant in person, or
+  - user gets the merchant ID / QR from social platforms or community channels.
+- Public discovery can be enabled later, after the subscription flow is considered complete enough.
+
+## Launch Strategy
+
+The app will go through a 30-day testing period (individual developer app store limitation) before public release. Tier 1 through Tier 3 should be completed during the testing period, so that all items are ready by the time the app is publicly available.
+
+## Implementation Priority
+
+### Tier 1 — Core Reliability (must complete before public release)
+
+| # | Item | Rationale |
+|---|------|-----------|
+| 1 | Device Health / Rebind Flow | Push notifications failing silently is the biggest trust problem. Users have no recovery path when tokens become invalid. |
+| 2 | Login Throttling / Brute-force Protection | Security baseline. Low implementation cost, high risk if missing. |
+| 3 | Refresh-token Rotation | Security baseline. Without rotation, a stolen refresh token grants permanent access. |
+| 4 | Password Hashing Upgrade (Argon2id) | No existing users yet, so switching from bcrypt is a one-time change with zero migration cost. Deferring would require dual-hash verification and gradual rehashing. |
+
+Device Health current state:
+- Device management APIs exist for register / token update / deactivate.
+- Invalid tokens are cleaned up during push processing, but there is no user-facing health or recovery flow.
+- Relevant files:
+  - [internal/delivery/api/router/handler/device_handler.go](../internal/delivery/api/router/handler/device_handler.go#L33)
+  - [internal/delivery/worker/handler/push_handler.go](../internal/delivery/worker/handler/push_handler.go#L357)
+  - [internal/usecase/impl/notification_service.go](../internal/usecase/impl/notification_service.go#L119)
+
+### Tier 2 — Merchant Operational Experience
+
+| # | Item | Rationale |
+|---|------|-----------|
+| 5 | Scheduled Notification / Draft / Preview | Biggest merchant pain point. Food trucks need to prepare notifications before departure. |
+| 6 | Merchant Notification Analytics / Subscriber Operations View | Key to merchant retention. Merchants need to see whether notifications are working and how many subscribers they have. |
+| 7 | Merchant Profile Maintenance API | Basic CRUD for merchant self-service. Low cost, can be interleaved with other work. |
+
+Scheduled Notification current state:
+- Current notification publishing flow is immediate-send oriented.
+- Relevant files:
+  - [internal/delivery/api/router/handler/notification_handler.go](../internal/delivery/api/router/handler/notification_handler.go#L57)
+  - [internal/usecase/impl/notification_service.go](../internal/usecase/impl/notification_service.go#L73)
+
+### Tier 3 — Auth Completeness + Email Infrastructure
+
+| # | Item | Rationale |
+|---|------|-----------|
+| 8 | Evaluate Amazon SES | Must select email infrastructure before building email-dependent features. Avoids a later migration. |
+| 9 | Email Verification | Depends on email infrastructure. Required before password reset can work. |
+| 10 | Forgot / Reset / Change Password | Depends on email verification. Standard self-service recovery path. |
+| 11 | Session Management / Device Sign-out Center | Natural extension of refresh-token rotation work from Tier 1. |
+
+### Tier 4 — Product Expansion (requires clarification first)
+
+| # | Item | Rationale |
+|---|------|-----------|
+| 12 | Subscription Pause / Resume vs Unsubscribe | Worth doing to prevent subscriber loss from users who just want to mute temporarily. Semantics need to be defined first. Notification radius remains intentionally fixed to the default value for now. |
+| 13 | Merchant Onboarding Setup Checklist | Most valuable after Tier 2 features are in place, otherwise the checklist has little content. |
+| 14 | Google Account Linking / Unlinking | Edge case. Most users choose their login method at registration time. |
+
+### Tier 5 — Deferred or Likely Unnecessary
+
+| # | Item | Rationale |
+|---|------|-----------|
+| 15 | User-side Merchant Status / Current Location Snapshot | Likely already covered by notification content. Observe whether users actually need a separate query page. |
+| 16 | Direct-share QR Flow | If the existing QR scan -> merchant ID -> subscribe path works, no additional development needed. |
+| 17 | Step-up Auth (TOTP MFA) | No payment or high-sensitivity data at this stage. Not needed. |
+| 18 | User Notification Inbox / History | Food truck notifications are time-sensitive. Yesterday's location has no value today. |
+| 19 | Merchant Discovery / Nearby Search | Intentionally deferred roadmap decision. Current acquisition is offline + social. Revisit after subscription flow is mature. |

--- a/docs/serverless-geo-notification-system.md
+++ b/docs/serverless-geo-notification-system.md
@@ -30,7 +30,7 @@ Refactor the existing synchronous notification system to an asynchronous Pub/Sub
 
 ## Implementation Steps
 
-### Phase 1: EventPublisher Infrastructure
+### Phase 1: EventPublisher Infrastructure ✅ COMPLETED
 
 #### 1.1 EventPublisher Interface
 
@@ -85,7 +85,7 @@ type PubSubConfig struct {
 
 ---
 
-### Phase 2: PMTiles Routing Service
+### Phase 2: PMTiles Routing Service ✅ COMPLETED
 
 #### 2.1 PMTiles Routing Implementation
 
@@ -146,7 +146,7 @@ type PMTilesConfig struct {
 
 ---
 
-### Phase 3: Geo Worker Service
+### Phase 3: Geo Worker Service ✅ COMPLETED
 
 #### 3.1 Worker Entry Point
 
@@ -174,7 +174,7 @@ func (w *Worker) HandlePush(c echo.Context) error {
 
 ---
 
-### Phase 4: Modify Existing Notification Flow
+### Phase 4: Modify Existing Notification Flow ✅ COMPLETED
 
 #### 4.1 Modify NotificationService
 
@@ -206,7 +206,7 @@ func (s *notificationService) PublishLocationNotification(...) (*entity.Merchant
 
 ---
 
-### Phase 5: Local Development Setup
+### Phase 5: Local Development Setup ✅ COMPLETED
 
 #### 5.1 Docker Compose Service Addition
 


### PR DESCRIPTION
## Summary
- update README to describe the current async notification flow
- mark the serverless geo notification implementation phases as completed
- add product priority notes for launch planning and deferred roadmap items

## Review
- verified the doc changes against the current async Pub/Sub + geoworker implementation
- corrected the README engine reference to PMTiles-based routing
- replaced local absolute file links in the new doc with repo-relative links