### PR TITLE
feat: add Cloud Run job deploy workflows

### DIFF
--- a/.github/workflows/deploy-cloud-run-job-dev.yml
+++ b/.github/workflows/deploy-cloud-run-job-dev.yml
@@ -1,0 +1,61 @@
+name: Deploy Cloud Run Job Dev
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Deploy target"
+        required: true
+        type: choice
+        options:
+          - device-cleanup
+      image_ref:
+        description: "Required image tag or commit SHA to deploy."
+        required: true
+        default: ""
+      run_migration:
+        description: "Run shared database migrations before deploy when this release includes schema changes."
+        required: false
+        type: boolean
+        default: false
+      configure_scheduler:
+        description: "Create or update Cloud Scheduler trigger. Leave off for image-only job deploys."
+        required: false
+        type: boolean
+        default: false
+      execute_now:
+        description: "Execute the Cloud Run Job immediately after deploy"
+        required: false
+        type: boolean
+        default: false
+      schedule:
+        description: "Cloud Scheduler cron expression"
+        required: false
+        type: string
+        default: "0 3 * * *"
+      schedule_time_zone:
+        description: "Cloud Scheduler time zone"
+        required: false
+        type: string
+        default: "Asia/Taipei"
+      scheduler_name:
+        description: "Cloud Scheduler job name"
+        required: false
+        type: string
+        default: "device-cleanup-daily"
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/deploy-cloud-run-reusable.yml
+    with:
+      environment_name: dev
+      resource_type: job
+      target: ${{ inputs.target }}
+      image_ref: ${{ inputs.image_ref }}
+      run_migration: ${{ inputs.run_migration }}
+      configure_scheduler: ${{ inputs.configure_scheduler }}
+      execute_now: ${{ inputs.execute_now }}
+      schedule: ${{ inputs.schedule }}
+      schedule_time_zone: ${{ inputs.schedule_time_zone }}
+      scheduler_name: ${{ inputs.scheduler_name }}
+    secrets: inherit

--- a/.github/workflows/deploy-cloud-run-job-prod.yml
+++ b/.github/workflows/deploy-cloud-run-job-prod.yml
@@ -1,0 +1,61 @@
+name: Deploy Cloud Run Job Prod
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Deploy target"
+        required: true
+        type: choice
+        options:
+          - device-cleanup
+      image_ref:
+        description: "Required image tag or commit SHA to deploy."
+        required: true
+        default: ""
+      run_migration:
+        description: "Run shared database migrations before deploy when this release includes schema changes."
+        required: false
+        type: boolean
+        default: false
+      configure_scheduler:
+        description: "Create or update Cloud Scheduler trigger. Leave off for image-only job deploys."
+        required: false
+        type: boolean
+        default: false
+      execute_now:
+        description: "Execute the Cloud Run Job immediately after deploy"
+        required: false
+        type: boolean
+        default: false
+      schedule:
+        description: "Cloud Scheduler cron expression"
+        required: false
+        type: string
+        default: "0 3 * * *"
+      schedule_time_zone:
+        description: "Cloud Scheduler time zone"
+        required: false
+        type: string
+        default: "Asia/Taipei"
+      scheduler_name:
+        description: "Cloud Scheduler job name"
+        required: false
+        type: string
+        default: "device-cleanup-daily"
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/deploy-cloud-run-reusable.yml
+    with:
+      environment_name: prod
+      resource_type: job
+      target: ${{ inputs.target }}
+      image_ref: ${{ inputs.image_ref }}
+      run_migration: ${{ inputs.run_migration }}
+      configure_scheduler: ${{ inputs.configure_scheduler }}
+      execute_now: ${{ inputs.execute_now }}
+      schedule: ${{ inputs.schedule }}
+      schedule_time_zone: ${{ inputs.schedule_time_zone }}
+      scheduler_name: ${{ inputs.scheduler_name }}
+    secrets: inherit

--- a/.github/workflows/deploy-cloud-run-reusable.yml
+++ b/.github/workflows/deploy-cloud-run-reusable.yml
@@ -7,6 +7,11 @@ on:
         description: "GitHub environment name"
         required: true
         type: string
+      resource_type:
+        description: "Cloud Run resource type: service or job"
+        required: false
+        default: service
+        type: string
       target:
         description: "Deploy target"
         required: true
@@ -25,10 +30,35 @@ on:
         required: false
         default: false
         type: boolean
+      configure_scheduler:
+        description: "Create or update the Cloud Scheduler trigger for Cloud Run Jobs"
+        required: false
+        default: false
+        type: boolean
+      execute_now:
+        description: "Execute the Cloud Run Job immediately after deploy"
+        required: false
+        default: false
+        type: boolean
+      schedule:
+        description: "Cloud Scheduler cron expression for Cloud Run Jobs"
+        required: false
+        default: "0 3 * * *"
+        type: string
+      schedule_time_zone:
+        description: "Cloud Scheduler time zone for Cloud Run Jobs"
+        required: false
+        default: "Asia/Taipei"
+        type: string
+      scheduler_name:
+        description: "Cloud Scheduler job name for Cloud Run Jobs"
+        required: false
+        default: ""
+        type: string
 
 jobs:
   deploy:
-    name: Deploy ${{ inputs.target }} to ${{ inputs.environment_name }}
+    name: Deploy ${{ inputs.resource_type }} ${{ inputs.target }} to ${{ inputs.environment_name }}
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment_name }}
     permissions:
@@ -41,15 +71,52 @@ jobs:
       GCP_SA_EMAIL: ${{ vars.GCP_SA_EMAIL }}
       GOOGLE_OAUTH_CLIENT_ID: ${{ vars.GOOGLEOAUTH_CLIENTID }}
     steps:
-      - name: Validate deployment configuration
+      - name: Validate common deployment configuration
         env:
           GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
         run: |
           set -euo pipefail
 
-          for required in PROJECT_ID REGION REGISTRY ALLOWED_HOST GCP_SA_EMAIL GOOGLE_OAUTH_CLIENT_ID GCP_SA_KEY; do
+          for required in PROJECT_ID REGION REGISTRY GCP_SA_EMAIL GCP_SA_KEY; do
             if [ -z "${!required:-}" ]; then
               echo "::error::Missing required deployment configuration: ${required}"
+              exit 1
+            fi
+          done
+
+          case "${{ inputs.resource_type }}" in
+            service)
+              case "${{ inputs.target }}" in
+                radar|geoworker) ;;
+                *)
+                  echo "::error::Unsupported Cloud Run service target: ${{ inputs.target }}"
+                  exit 1
+                  ;;
+              esac
+              ;;
+            job)
+              case "${{ inputs.target }}" in
+                device-cleanup) ;;
+                *)
+                  echo "::error::Unsupported Cloud Run job target: ${{ inputs.target }}"
+                  exit 1
+                  ;;
+              esac
+              ;;
+            *)
+              echo "::error::Unsupported resource_type: ${{ inputs.resource_type }}"
+              exit 1
+              ;;
+          esac
+
+      - name: Validate service deployment configuration
+        if: ${{ inputs.resource_type == 'service' }}
+        run: |
+          set -euo pipefail
+
+          for required in ALLOWED_HOST GOOGLE_OAUTH_CLIENT_ID; do
+            if [ -z "${!required:-}" ]; then
+              echo "::error::Missing required service deployment configuration: ${required}"
               exit 1
             fi
           done
@@ -138,6 +205,7 @@ jobs:
             --format='value(image_summary.fully_qualified_digest)'
 
       - name: Prepare service YAML
+        if: ${{ inputs.resource_type == 'service' }}
         env:
           CLOUDFLARE_ORIGIN_SECRET: ${{ secrets.CLOUDFLARE_ORIGIN_SECRET }}
         run: |
@@ -167,7 +235,8 @@ jobs:
             sed -i "s|HTTP_CLOUDFLARESECRET_PLACEHOLDER|${CLOUDFLARE_SECRET_ESCAPED}|g" /tmp/service.yaml
           fi
 
-      - name: Deploy to Cloud Run
+      - name: Deploy Cloud Run service
+        if: ${{ inputs.resource_type == 'service' }}
         id: deploy
         run: |
           set -euo pipefail
@@ -184,8 +253,84 @@ jobs:
               --role="roles/run.invoker"
           fi
 
+      - name: Deploy Cloud Run job
+        if: ${{ inputs.resource_type == 'job' }}
+        run: |
+          set -euo pipefail
+
+          case "${{ inputs.target }}" in
+            device-cleanup)
+              gcloud run jobs deploy "${{ inputs.target }}" \
+                --image="${{ steps.image.outputs.name }}" \
+                --project="${PROJECT_ID}" \
+                --region="${REGION}" \
+                --service-account="${GCP_SA_EMAIL}" \
+                --tasks=1 \
+                --parallelism=1 \
+                --memory=512Mi \
+                --cpu=1 \
+                --task-timeout=10m \
+                --set-env-vars="ENV_LOG_PRETTY=false,ENV_LOG_LEVEL=info,POSTGRES_PRESET=supabase_transaction,POSTGRES_SSLMODE=require,POSTGRES_MAXOPENCONNS=5" \
+                --set-secrets="POSTGRES_MASTER_DSN=postgres-master-dsn:latest" \
+                --quiet
+              ;;
+            *)
+              echo "::error::Missing Cloud Run Job deployment configuration for target: ${{ inputs.target }}"
+              exit 1
+              ;;
+          esac
+
+      - name: Configure Cloud Scheduler for job
+        if: ${{ inputs.resource_type == 'job' && inputs.configure_scheduler }}
+        run: |
+          set -euo pipefail
+
+          SCHEDULER_JOB_NAME="${{ inputs.scheduler_name }}"
+          if [ -z "${SCHEDULER_JOB_NAME}" ]; then
+            echo "::error::scheduler_name is required when configure_scheduler is enabled."
+            exit 1
+          fi
+
+          JOB_RUN_URI="https://run.googleapis.com/v2/projects/${PROJECT_ID}/locations/${REGION}/jobs/${{ inputs.target }}:run"
+
+          if gcloud scheduler jobs describe "${SCHEDULER_JOB_NAME}" \
+            --project="${PROJECT_ID}" \
+            --location="${REGION}" >/dev/null 2>&1; then
+            gcloud scheduler jobs update http "${SCHEDULER_JOB_NAME}" \
+              --project="${PROJECT_ID}" \
+              --location="${REGION}" \
+              --schedule="${{ inputs.schedule }}" \
+              --time-zone="${{ inputs.schedule_time_zone }}" \
+              --uri="${JOB_RUN_URI}" \
+              --http-method=POST \
+              --oauth-service-account-email="${GCP_SA_EMAIL}" \
+              --oauth-token-scope="https://www.googleapis.com/auth/cloud-platform" \
+              --quiet
+          else
+            gcloud scheduler jobs create http "${SCHEDULER_JOB_NAME}" \
+              --project="${PROJECT_ID}" \
+              --location="${REGION}" \
+              --schedule="${{ inputs.schedule }}" \
+              --time-zone="${{ inputs.schedule_time_zone }}" \
+              --uri="${JOB_RUN_URI}" \
+              --http-method=POST \
+              --oauth-service-account-email="${GCP_SA_EMAIL}" \
+              --oauth-token-scope="https://www.googleapis.com/auth/cloud-platform" \
+              --quiet
+          fi
+
+      - name: Execute Cloud Run job
+        if: ${{ inputs.resource_type == 'job' && inputs.execute_now }}
+        run: |
+          set -euo pipefail
+
+          gcloud run jobs execute "${{ inputs.target }}" \
+            --project="${PROJECT_ID}" \
+            --region="${REGION}" \
+            --wait
+
       - name: Sync Cloudflare Transform Rule Header
-        if: ${{ inputs.enable_cloudflare_sync && inputs.target == 'radar' }}
+        if: ${{ inputs.resource_type == 'service' && inputs.enable_cloudflare_sync && inputs.target == 'radar' }}
         env:
           CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CF_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
@@ -244,7 +389,8 @@ jobs:
             exit 1
           fi
 
-      - name: Show Output
+      - name: Show service output
+        if: ${{ inputs.resource_type == 'service' }}
         run: |
           set -euo pipefail
 
@@ -252,3 +398,13 @@ jobs:
             --project="${PROJECT_ID}" \
             --region="${REGION}" \
             --format='value(status.url)'
+
+      - name: Show job output
+        if: ${{ inputs.resource_type == 'job' }}
+        run: |
+          set -euo pipefail
+
+          gcloud run jobs describe "${{ inputs.target }}" \
+            --project="${PROJECT_ID}" \
+            --region="${REGION}" \
+            --format='yaml(name,spec.template.spec.taskCount,spec.template.spec.parallelism,spec.template.spec.template.spec.containers[0].image,status.latestCreatedExecution.name)'

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,4 +1,4 @@
-name: Deploy Dev
+name: Deploy Cloud Run Service Dev
 
 on:
   workflow_dispatch:
@@ -25,6 +25,7 @@ jobs:
     uses: ./.github/workflows/deploy-cloud-run-reusable.yml
     with:
       environment_name: dev
+      resource_type: service
       target: ${{ inputs.target }}
       image_ref: ${{ inputs.image_ref }}
       run_migration: ${{ inputs.run_migration }}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,4 +1,4 @@
-name: Deploy Prod
+name: Deploy Cloud Run Service Prod
 
 on:
   workflow_dispatch:
@@ -25,6 +25,7 @@ jobs:
     uses: ./.github/workflows/deploy-cloud-run-reusable.yml
     with:
       environment_name: prod
+      resource_type: service
       target: ${{ inputs.target }}
       image_ref: ${{ inputs.image_ref }}
       run_migration: ${{ inputs.run_migration }}

--- a/docs/cloud-run-jobs.md
+++ b/docs/cloud-run-jobs.md
@@ -52,7 +52,7 @@ The job deploy sets the same database and logging runtime configuration document
 Prerequisites for Scheduler management:
 
 - `cloudscheduler.googleapis.com` must be enabled in the target GCP project.
-- The workflow deployer service account needs permission to create or update Cloud Scheduler jobs, for example `roles/cloudscheduler.admin`.
+- The workflow deployer service account needs permission to create or update Cloud Scheduler jobs, for example `roles/cloudscheduler.jobEditor`, and `roles/iam.serviceAccountUser` on the scheduler service account.
 - The service account used by Cloud Scheduler must have permission to run the Cloud Run Job, for example `roles/run.invoker` on the target job or project.
 
 ### Manual Deploy Fallback

--- a/docs/cloud-run-jobs.md
+++ b/docs/cloud-run-jobs.md
@@ -25,7 +25,37 @@ ${REGISTRY}/${IMAGE_NAME}/device-cleanup:${TAG}
 ${REGISTRY}/${IMAGE_NAME}/device-cleanup:latest
 ```
 
-### Deploy Job
+### Deploy with GitHub Actions
+
+Use the dedicated workflow for the target environment:
+
+- `Deploy Cloud Run Job Dev`
+- `Deploy Cloud Run Job Prod`
+
+Inputs:
+
+| Input | Description |
+|-------|-------------|
+| `target` | Cloud Run Job target. Currently only `device-cleanup`. |
+| `image_ref` | Required image tag or commit SHA to deploy. |
+| `run_migration` | Runs the shared database migrations before deploy when this release includes schema changes. Defaults to `false`. |
+| `configure_scheduler` | Creates or updates the Cloud Scheduler trigger configured by `schedule`, `schedule_time_zone`, and `scheduler_name`. Leave disabled for image-only job deploys. Defaults to `false`. |
+| `execute_now` | Executes the job immediately after deploy. Defaults to `false`. |
+| `schedule` | Cloud Scheduler cron expression. Defaults to `0 3 * * *`. |
+| `schedule_time_zone` | Cloud Scheduler time zone. Defaults to `Asia/Taipei`. |
+| `scheduler_name` | Cloud Scheduler job name. Defaults to `device-cleanup-daily` for this job; change it if `schedule` is no longer daily or if adding another job target. |
+
+The workflow reuses the shared Cloud Run deployment setup used by services: Google auth, Artifact Registry image resolution, optional migration, and image existence verification. If `run_migration` is enabled, it runs the same goose migration path used by service deploys before deploying the job. The deployment branch for jobs runs `gcloud run jobs deploy` instead of `gcloud run services replace`.
+
+The job deploy sets the same database and logging runtime configuration documented below. Firebase and HTTP server settings are not required.
+
+Prerequisites for Scheduler management:
+
+- `cloudscheduler.googleapis.com` must be enabled in the target GCP project.
+- The workflow deployer service account needs permission to create or update Cloud Scheduler jobs, for example `roles/cloudscheduler.admin`.
+- The service account used by Cloud Scheduler must have permission to run the Cloud Run Job, for example `roles/run.invoker` on the target job or project.
+
+### Manual Deploy Fallback
 
 Deploy the image as a Cloud Run Job. Use the same database and logging environment variables as the `radar` service; Firebase and HTTP server settings are not required.
 
@@ -42,18 +72,22 @@ gcloud run jobs deploy device-cleanup \
 
 ### Schedule
 
-Create a Cloud Scheduler trigger that executes the job once per day:
+Cloud Scheduler is configured separately from the job image deploy. The GitHub Actions workflow creates or updates this scheduler only when `configure_scheduler` is enabled. Leave it disabled for normal image-only job deploys. Enable it when first creating the scheduler or intentionally changing `scheduler_name`, `schedule`, `schedule_time_zone`, URI, HTTP method, or OAuth scope.
+
+For manual fallback, create a Cloud Scheduler trigger that executes the job once per day:
 
 ```sh
 gcloud scheduler jobs create http device-cleanup-daily \
   --location REGION \
   --schedule "0 3 * * *" \
-  --uri "https://REGION-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/PROJECT_ID/jobs/device-cleanup:run" \
+  --time-zone "Asia/Taipei" \
+  --uri "https://run.googleapis.com/v2/projects/PROJECT_ID/locations/REGION/jobs/device-cleanup:run" \
   --http-method POST \
-  --oauth-service-account-email SERVICE_ACCOUNT
+  --oauth-service-account-email SERVICE_ACCOUNT \
+  --oauth-token-scope "https://www.googleapis.com/auth/cloud-platform"
 ```
 
-The service account used by Cloud Scheduler must have permission to run the Cloud Run Job.
+The workflow creates or updates the scheduler trigger, but it does not grant IAM. The service account used by Cloud Scheduler must already have permission to run the Cloud Run Job, for example `roles/run.invoker` on the target job or project.
 
 ### Manual Run
 


### PR DESCRIPTION
## Summary

- extend the shared Cloud Run deploy workflow to support service and job resources
- add dev/prod dispatch workflows for the device-cleanup Cloud Run Job
- document GitHub Actions deployment, Scheduler configuration, and required GCP permissions

## Validation
- ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].sort.each { |f| YAML.load_file(f); puts "ok #{f}" }'
- git diff --cached --check

## Notes
- Cloud Scheduler configuration is opt-in via configure_scheduler.
- Scheduler management requires cloudscheduler.googleapis.com and appropriate IAM on the deployer and Scheduler service accounts.