### PR TITLE
feat: add merchant discovery profile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ x-postgres-common: &postgres-common
     POSTGRES_USER: user
     POSTGRES_DB: auth_db
     POSTGRES_PASSWORD: password
+    PGDATA: /var/lib/postgresql/18/docker
     POSTGRES_INITDB_ARGS: "--auth-host=scram-sha-256 --auth-local=scram-sha-256 --data-checksums --encoding=UTF8 --locale=en_US.UTF-8"
   healthcheck:
     test: ["CMD-SHELL", "pg_isready -U user -d auth_db"]
@@ -34,7 +35,7 @@ services:
       -c archive_command='test ! -f /var/lib/postgresql/backup_in_progress || exit 1; test ! -f /var/lib/postgresql/archive/%f || cp %p /var/lib/postgresql/archive/%f; rm %p'
       -c archive_timeout=60
     volumes:
-      - postgres_master_data:/var/lib/postgresql/data
+      - postgres_master_data:/var/lib/postgresql
       - ./database/postgres/master:/docker-entrypoint-initdb.d
     networks:
       - radar-network
@@ -84,7 +85,7 @@ services:
       exec postgres -D \"\$$REPLICA_DATA_DIR\"
       "
     volumes:
-      - postgres_replica_data:/var/lib/postgresql/data
+      - postgres_replica_data:/var/lib/postgresql
     depends_on:
       postgres-master:
         condition: service_healthy

--- a/docs/tier2-plan.md
+++ b/docs/tier2-plan.md
@@ -76,11 +76,12 @@ Implementation guidance:
 
 Acceptance checklist:
 
-- [ ] Merchant can read current discovery profile.
-- [ ] Merchant can update category, subcategory, hub, and public visibility.
-- [ ] Invalid, inactive, or mismatched discovery values are rejected.
-- [ ] Unverified merchants or merchants without active primary location cannot enable public discovery.
-- [ ] Existing profile behavior remains compatible.
+- [x] Merchant can read current discovery profile.
+- [x] Merchant can update category, subcategory, hub, and public visibility.
+- [x] Merchant can clear the active hub.
+- [x] Invalid, inactive, or mismatched discovery values are rejected.
+- [x] Unverified merchants or merchants without active primary location cannot enable public discovery.
+- [x] Existing profile behavior remains compatible.
 
 ## Phase 3 - Consumer Discovery Search
 
@@ -141,4 +142,4 @@ Phase 1 creates the stable data model, Phase 2 lets merchants populate it, and P
 
 ## Status
 
-This is the Tier 2 execution guide. Update this section as each phase is implemented.
+Phase 2 merchant discovery profile is implemented with merchant read/update endpoints and usecase-level public discovery eligibility checks. Existing Phase 1 schema was kept because its nullable discovery fields and subcategory/category composite foreign key already support Phase 2 validation without additional migration changes.

--- a/internal/delivery/api/router/handler/user_handler.go
+++ b/internal/delivery/api/router/handler/user_handler.go
@@ -1,6 +1,8 @@
 package handler
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 	"log/slog"
 	"net/http"
@@ -12,6 +14,7 @@ import (
 	"radar/internal/domain/service"
 	"radar/internal/usecase"
 
+	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"go.uber.org/fx"
 )
@@ -37,6 +40,48 @@ type UserHandler struct {
 type GoogleCallbackQueryParams struct {
 	Code  string `query:"code"`
 	State string `query:"state"`
+}
+
+type optionalUUIDRequestField struct {
+	isSet bool
+	value *uuid.UUID
+}
+
+func (field *optionalUUIDRequestField) UnmarshalJSON(data []byte) error {
+	field.isSet = true
+	if bytes.Equal(bytes.TrimSpace(data), []byte("null")) {
+		field.value = nil
+
+		return nil
+	}
+
+	var raw string
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	parsed, err := uuid.Parse(raw)
+	if err != nil {
+		return err
+	}
+
+	field.value = &parsed
+
+	return nil
+}
+
+func (field optionalUUIDRequestField) toUsecase() usecase.OptionalUUIDUpdate {
+	return usecase.OptionalUUIDUpdate{
+		IsSet: field.isSet,
+		Value: field.value,
+	}
+}
+
+type UpdateMerchantDiscoveryProfileRequest struct {
+	DiscoveryCategoryID    optionalUUIDRequestField `json:"discovery_category_id"`
+	DiscoverySubcategoryID optionalUUIDRequestField `json:"discovery_subcategory_id"`
+	ActiveHubID            optionalUUIDRequestField `json:"active_hub_id"`
+	IsPublic               *bool                    `json:"is_public,omitempty"`
 }
 
 // NewUserHandler is the constructor for UserHandler, injected by Fx.
@@ -178,6 +223,44 @@ func (h *UserHandler) SubmitMerchantVerification(c echo.Context) error {
 	}
 
 	return response.Success(c, http.StatusOK, map[string]string{responseKeyStatus: "verified"})
+}
+
+func (h *UserHandler) GetMerchantDiscoveryProfile(c echo.Context) error {
+	userID, ok := middleware.GetUserID(c)
+	if !ok {
+		return response.Unauthorized(c, "INVALID_TOKEN", "Invalid user ID in token")
+	}
+
+	result, err := h.profileUC.GetMerchantDiscoveryProfile(c.Request().Context(), userID)
+	if err != nil {
+		return withSourceStack(err)
+	}
+
+	return response.Success(c, http.StatusOK, result)
+}
+
+func (h *UserHandler) UpdateMerchantDiscoveryProfile(c echo.Context) error {
+	userID, ok := middleware.GetUserID(c)
+	if !ok {
+		return response.Unauthorized(c, "INVALID_TOKEN", "Invalid user ID in token")
+	}
+
+	var req UpdateMerchantDiscoveryProfileRequest
+	if err := bindRequest(c, &req, "Invalid merchant discovery profile input"); err != nil {
+		return err
+	}
+
+	result, err := h.profileUC.UpdateMerchantDiscoveryProfile(c.Request().Context(), userID, &usecase.UpdateMerchantDiscoveryProfileInput{
+		DiscoveryCategoryID:    req.DiscoveryCategoryID.toUsecase(),
+		DiscoverySubcategoryID: req.DiscoverySubcategoryID.toUsecase(),
+		ActiveHubID:            req.ActiveHubID.toUsecase(),
+		IsPublic:               req.IsPublic,
+	})
+	if err != nil {
+		return withSourceStack(err)
+	}
+
+	return response.Success(c, http.StatusOK, result)
 }
 
 func (h *UserHandler) LinkProvider(c echo.Context) error {

--- a/internal/delivery/api/router/handler/user_handler_discovery_profile_test.go
+++ b/internal/delivery/api/router/handler/user_handler_discovery_profile_test.go
@@ -1,0 +1,73 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"radar/internal/domain/entity"
+	"radar/internal/usecase"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type recordingProfileUsecase struct {
+	updateInput *usecase.UpdateMerchantDiscoveryProfileInput
+}
+
+func (uc *recordingProfileUsecase) GetProfile(_ context.Context, _ uuid.UUID) (*entity.User, error) {
+	return nil, nil
+}
+
+func (uc *recordingProfileUsecase) UpdateUserProfile(_ context.Context, _ uuid.UUID, _ *usecase.UpdateUserProfileInput) error {
+	return nil
+}
+
+func (uc *recordingProfileUsecase) UpdateMerchantProfile(_ context.Context, _ uuid.UUID, _ *usecase.UpdateMerchantProfileInput) error {
+	return nil
+}
+
+func (uc *recordingProfileUsecase) GetMerchantDiscoveryProfile(_ context.Context, _ uuid.UUID) (*usecase.MerchantDiscoveryProfileResult, error) {
+	return &usecase.MerchantDiscoveryProfileResult{}, nil
+}
+
+func (uc *recordingProfileUsecase) UpdateMerchantDiscoveryProfile(
+	_ context.Context,
+	_ uuid.UUID,
+	input *usecase.UpdateMerchantDiscoveryProfileInput,
+) (*usecase.MerchantDiscoveryProfileResult, error) {
+	uc.updateInput = input
+
+	return &usecase.MerchantDiscoveryProfileResult{}, nil
+}
+
+func (uc *recordingProfileUsecase) SubmitMerchantVerification(_ context.Context, _ uuid.UUID, _ *usecase.SubmitMerchantVerificationInput) error {
+	return nil
+}
+
+func (uc *recordingProfileUsecase) SwitchToMerchant(_ context.Context, _ uuid.UUID, _ *usecase.SwitchToMerchantInput) error {
+	return nil
+}
+
+func (uc *recordingProfileUsecase) GetUserRole(_ context.Context, _ uuid.UUID) ([]string, error) {
+	return nil, nil
+}
+
+func TestUserHandler_UpdateMerchantDiscoveryProfile_ParsesNullActiveHubAsClear(t *testing.T) {
+	profileUC := &recordingProfileUsecase{}
+	handler := &UserHandler{profileUC: profileUC}
+	c, rec := newJSONContext(http.MethodPatch, "/merchant/discovery-profile", `{"active_hub_id":null,"is_public":false}`)
+	c.Set("userID", uuid.New())
+
+	err := handler.UpdateMerchantDiscoveryProfile(c)
+
+	require.NoError(t, err)
+	require.NotNil(t, profileUC.updateInput)
+	assert.True(t, profileUC.updateInput.ActiveHubID.IsSet)
+	assert.Nil(t, profileUC.updateInput.ActiveHubID.Value)
+	require.NotNil(t, profileUC.updateInput.IsPublic)
+	assert.False(t, *profileUC.updateInput.IsPublic)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}

--- a/internal/delivery/api/router/handler/user_handler_validation_test.go
+++ b/internal/delivery/api/router/handler/user_handler_validation_test.go
@@ -106,3 +106,16 @@ func TestUserHandler_InvalidPayloadsAreRejectedAtHTTPBoundary(t *testing.T) {
 		})
 	}
 }
+
+func TestUserHandler_UpdateMerchantDiscoveryProfile_InvalidUUIDRejectedAtHTTPBoundary(t *testing.T) {
+	handler := &UserHandler{}
+	c, rec := newJSONContext(http.MethodPatch, "/merchant/discovery-profile", `{"discovery_category_id":"not-a-uuid"}`)
+	c.Set("userID", uuid.New())
+
+	err := handler.UpdateMerchantDiscoveryProfile(c)
+
+	require.ErrorIs(t, err, delivery.ErrResponseHandled)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), `"code":"INVALID_INPUT"`)
+	assert.Contains(t, rec.Body.String(), `"message":"Invalid merchant discovery profile input"`)
+}

--- a/internal/delivery/api/router/router.go
+++ b/internal/delivery/api/router/router.go
@@ -160,6 +160,8 @@ func (r *router) registerAPIV1MerchantRoutes(apiV1 *echo.Group) {
 	{
 		merchantGroup.GET("/qr", r.subscriptionHandler.GenerateSubscriptionQR)
 		merchantGroup.POST("/verification", r.userHandler.SubmitMerchantVerification)
+		merchantGroup.GET("/discovery-profile", r.userHandler.GetMerchantDiscoveryProfile)
+		merchantGroup.PATCH("/discovery-profile", r.userHandler.UpdateMerchantDiscoveryProfile)
 	}
 
 	merchantMenusGroup := apiV1.Group("/menus/merchant")

--- a/internal/usecase/impl/profile_service.go
+++ b/internal/usecase/impl/profile_service.go
@@ -156,6 +156,130 @@ func (srv *profileService) UpdateMerchantProfile(ctx context.Context, userID uui
 	return nil
 }
 
+func (srv *profileService) GetMerchantDiscoveryProfile(ctx context.Context, userID uuid.UUID) (*usecase.MerchantDiscoveryProfileResult, error) {
+	srv.log(ctx).Debug("Getting merchant discovery profile", slog.String("user_id", userID.String()))
+
+	var result *usecase.MerchantDiscoveryProfileResult
+
+	err := srv.txManager.Execute(ctx, func(repoFactory repository.RepositoryFactory) error {
+		userRepo := repoFactory.UserRepo()
+		discoveryRepo := repoFactory.DiscoveryRepo()
+		addressRepo := repoFactory.AddressRepo()
+
+		user, err := userRepo.FindByID(ctx, userID)
+		if err != nil {
+			if errors.Is(err, domainerrors.ErrUserNotFound) {
+				return domainerrors.ErrNotFound
+			}
+
+			return err
+		}
+		if user.MerchantProfile == nil {
+			return domainerrors.ErrValidationFailed.WithDetails("user does not have a merchant profile")
+		}
+
+		hasActivePrimaryLocation, err := merchantHasActivePrimaryLocation(ctx, addressRepo, userID)
+		if err != nil {
+			return err
+		}
+
+		resolved, err := buildMerchantDiscoveryProfileResult(ctx, discoveryRepo, user.MerchantProfile, hasActivePrimaryLocation)
+		if err != nil {
+			return err
+		}
+		result = resolved
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func (srv *profileService) UpdateMerchantDiscoveryProfile(ctx context.Context, userID uuid.UUID, input *usecase.UpdateMerchantDiscoveryProfileInput) (*usecase.MerchantDiscoveryProfileResult, error) {
+	srv.log(ctx).Info("Updating merchant discovery profile", slog.String("user_id", userID.String()))
+	if input == nil {
+		return nil, domainerrors.ErrValidationFailed.WithDetails("discovery profile input is required")
+	}
+
+	var result *usecase.MerchantDiscoveryProfileResult
+
+	err := srv.txManager.Execute(ctx, func(repoFactory repository.RepositoryFactory) error {
+		userRepo := repoFactory.UserRepo()
+		discoveryRepo := repoFactory.DiscoveryRepo()
+		addressRepo := repoFactory.AddressRepo()
+
+		user, err := userRepo.FindByID(ctx, userID)
+		if err != nil {
+			if errors.Is(err, domainerrors.ErrUserNotFound) {
+				return domainerrors.ErrNotFound
+			}
+
+			return err
+		}
+		if user.MerchantProfile == nil {
+			return domainerrors.ErrValidationFailed.WithDetails("user does not have a merchant profile")
+		}
+
+		profile := user.MerchantProfile
+		categoryID := profile.DiscoveryCategoryID
+		subcategoryID := profile.DiscoverySubcategoryID
+		hubID := profile.ActiveHubID
+		isPublic := profile.IsPublic
+
+		if input.DiscoveryCategoryID.IsSet {
+			categoryID = input.DiscoveryCategoryID.Value
+		}
+		if input.DiscoverySubcategoryID.IsSet {
+			subcategoryID = input.DiscoverySubcategoryID.Value
+		}
+		if input.ActiveHubID.IsSet {
+			hubID = input.ActiveHubID.Value
+		}
+		if input.IsPublic != nil {
+			isPublic = *input.IsPublic
+		}
+
+		if err := validateMerchantDiscoveryUpdateValues(ctx, discoveryRepo, input, categoryID, subcategoryID, hubID, isPublic); err != nil {
+			return err
+		}
+
+		hasActivePrimaryLocation, err := merchantHasActivePrimaryLocation(ctx, addressRepo, userID)
+		if err != nil {
+			return err
+		}
+		if isPublic {
+			if err := validateMerchantDiscoveryEligibility(profile, categoryID, subcategoryID, hasActivePrimaryLocation); err != nil {
+				return err
+			}
+		}
+
+		profile.DiscoveryCategoryID = categoryID
+		profile.DiscoverySubcategoryID = subcategoryID
+		profile.ActiveHubID = hubID
+		profile.IsPublic = isPublic
+
+		if err := userRepo.Update(ctx, user); err != nil {
+			return err
+		}
+
+		resolved, err := buildMerchantDiscoveryProfileResult(ctx, discoveryRepo, profile, hasActivePrimaryLocation)
+		if err != nil {
+			return err
+		}
+		result = resolved
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
 func (srv *profileService) SubmitMerchantVerification(ctx context.Context, userID uuid.UUID, input *usecase.SubmitMerchantVerificationInput) error {
 	srv.log(ctx).Info("Submitting merchant verification", slog.String("user_id", userID.String()))
 
@@ -251,6 +375,216 @@ func (srv *profileService) SwitchToMerchant(ctx context.Context, userID uuid.UUI
 	srv.log(ctx).Debug("user switched to merchant", slog.String("user_id", userID.String()))
 
 	return nil
+}
+
+func validateMerchantDiscoveryValues(
+	ctx context.Context,
+	discoveryRepo repository.DiscoveryRepository,
+	categoryID *uuid.UUID,
+	subcategoryID *uuid.UUID,
+	hubID *uuid.UUID,
+) error {
+	var category *entity.DiscoveryCategory
+	if categoryID != nil {
+		foundCategory, err := discoveryRepo.FindCategoryByID(ctx, *categoryID)
+		if err != nil {
+			return err
+		}
+		if foundCategory.Status != entity.DiscoveryStatusActive {
+			return domainerrors.ErrValidationFailed.WithDetails("discovery_category_id must reference an active category")
+		}
+		category = foundCategory
+	}
+
+	if subcategoryID != nil {
+		if category == nil {
+			return domainerrors.ErrValidationFailed.WithDetails("discovery_subcategory_id requires discovery_category_id")
+		}
+
+		subcategory, err := discoveryRepo.FindSubcategoryByID(ctx, *subcategoryID)
+		if err != nil {
+			return err
+		}
+		if subcategory.Status != entity.DiscoveryStatusActive {
+			return domainerrors.ErrValidationFailed.WithDetails("discovery_subcategory_id must reference an active subcategory")
+		}
+		if subcategory.CategoryID != category.ID {
+			return domainerrors.ErrValidationFailed.WithDetails("discovery_subcategory_id must belong to discovery_category_id")
+		}
+	}
+
+	if hubID != nil {
+		hub, err := discoveryRepo.FindHubByID(ctx, *hubID)
+		if err != nil {
+			return err
+		}
+		if hub.Status != entity.DiscoveryStatusActive {
+			return domainerrors.ErrValidationFailed.WithDetails("active_hub_id must reference an active hub")
+		}
+	}
+
+	return nil
+}
+
+func validateMerchantDiscoveryUpdateValues(
+	ctx context.Context,
+	discoveryRepo repository.DiscoveryRepository,
+	input *usecase.UpdateMerchantDiscoveryProfileInput,
+	categoryID *uuid.UUID,
+	subcategoryID *uuid.UUID,
+	hubID *uuid.UUID,
+	isPublic bool,
+) error {
+	if isPublic {
+		return validateMerchantDiscoveryValues(ctx, discoveryRepo, categoryID, subcategoryID, hubID)
+	}
+
+	return validateSelectedMerchantDiscoveryValues(ctx, discoveryRepo, input, categoryID, subcategoryID, hubID)
+}
+
+func validateSelectedMerchantDiscoveryValues(
+	ctx context.Context,
+	discoveryRepo repository.DiscoveryRepository,
+	input *usecase.UpdateMerchantDiscoveryProfileInput,
+	categoryID *uuid.UUID,
+	subcategoryID *uuid.UUID,
+	hubID *uuid.UUID,
+) error {
+	if input.DiscoveryCategoryID.IsSet && categoryID != nil {
+		category, err := discoveryRepo.FindCategoryByID(ctx, *categoryID)
+		if err != nil {
+			return err
+		}
+		if category.Status != entity.DiscoveryStatusActive {
+			return domainerrors.ErrValidationFailed.WithDetails("discovery_category_id must reference an active category")
+		}
+	}
+
+	if input.DiscoverySubcategoryID.IsSet && subcategoryID != nil {
+		if categoryID == nil {
+			return domainerrors.ErrValidationFailed.WithDetails("discovery_subcategory_id requires discovery_category_id")
+		}
+
+		subcategory, err := discoveryRepo.FindSubcategoryByID(ctx, *subcategoryID)
+		if err != nil {
+			return err
+		}
+		if subcategory.Status != entity.DiscoveryStatusActive {
+			return domainerrors.ErrValidationFailed.WithDetails("discovery_subcategory_id must reference an active subcategory")
+		}
+		if subcategory.CategoryID != *categoryID {
+			return domainerrors.ErrValidationFailed.WithDetails("discovery_subcategory_id must belong to discovery_category_id")
+		}
+	}
+
+	// Category changed in this PATCH but subcategory was kept. Re-verify the
+	// kept subcategory still belongs to the new category without requiring it
+	// to be active while the merchant remains private.
+	if input.DiscoveryCategoryID.IsSet && !input.DiscoverySubcategoryID.IsSet && subcategoryID != nil {
+		if categoryID == nil {
+			return domainerrors.ErrValidationFailed.WithDetails("discovery_subcategory_id requires discovery_category_id")
+		}
+
+		subcategory, err := discoveryRepo.FindSubcategoryByID(ctx, *subcategoryID)
+		if err != nil {
+			return err
+		}
+		if subcategory.CategoryID != *categoryID {
+			return domainerrors.ErrValidationFailed.WithDetails("discovery_subcategory_id must belong to discovery_category_id")
+		}
+	}
+
+	if input.ActiveHubID.IsSet && hubID != nil {
+		hub, err := discoveryRepo.FindHubByID(ctx, *hubID)
+		if err != nil {
+			return err
+		}
+		if hub.Status != entity.DiscoveryStatusActive {
+			return domainerrors.ErrValidationFailed.WithDetails("active_hub_id must reference an active hub")
+		}
+	}
+
+	return nil
+}
+
+func validateMerchantDiscoveryEligibility(
+	profile *entity.MerchantProfile,
+	categoryID *uuid.UUID,
+	subcategoryID *uuid.UUID,
+	hasActivePrimaryLocation bool,
+) error {
+	if profile.VerificationStatus != entity.MerchantVerificationStatusVerified {
+		return domainerrors.ErrValidationFailed.WithDetails("merchant must be verified before enabling public discovery")
+	}
+	if categoryID == nil {
+		return domainerrors.ErrValidationFailed.WithDetails("discovery_category_id is required before enabling public discovery")
+	}
+	if subcategoryID == nil {
+		return domainerrors.ErrValidationFailed.WithDetails("discovery_subcategory_id is required before enabling public discovery")
+	}
+	if !hasActivePrimaryLocation {
+		return domainerrors.ErrValidationFailed.WithDetails("active primary merchant location is required before enabling public discovery")
+	}
+
+	return nil
+}
+
+func merchantHasActivePrimaryLocation(
+	ctx context.Context,
+	addressRepo repository.AddressRepository,
+	merchantID uuid.UUID,
+) (bool, error) {
+	addresses, err := addressRepo.FindActiveAddressesByOwner(ctx, merchantID, entity.OwnerTypeMerchantProfile)
+	if err != nil {
+		return false, err
+	}
+	for _, address := range addresses {
+		if address.IsPrimary {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func buildMerchantDiscoveryProfileResult(
+	ctx context.Context,
+	discoveryRepo repository.DiscoveryRepository,
+	profile *entity.MerchantProfile,
+	hasActivePrimaryLocation bool,
+) (*usecase.MerchantDiscoveryProfileResult, error) {
+	result := &usecase.MerchantDiscoveryProfileResult{
+		DiscoveryCategoryID:      profile.DiscoveryCategoryID,
+		DiscoverySubcategoryID:   profile.DiscoverySubcategoryID,
+		ActiveHubID:              profile.ActiveHubID,
+		IsPublic:                 profile.IsPublic,
+		IsVerified:               profile.VerificationStatus == entity.MerchantVerificationStatusVerified,
+		HasActivePrimaryLocation: hasActivePrimaryLocation,
+	}
+
+	if profile.DiscoveryCategoryID != nil {
+		category, err := discoveryRepo.FindCategoryByID(ctx, *profile.DiscoveryCategoryID)
+		if err != nil {
+			return nil, err
+		}
+		result.DiscoveryCategory = category
+	}
+	if profile.DiscoverySubcategoryID != nil {
+		subcategory, err := discoveryRepo.FindSubcategoryByID(ctx, *profile.DiscoverySubcategoryID)
+		if err != nil {
+			return nil, err
+		}
+		result.DiscoverySubcategory = subcategory
+	}
+	if profile.ActiveHubID != nil {
+		hub, err := discoveryRepo.FindHubByID(ctx, *profile.ActiveHubID)
+		if err != nil {
+			return nil, err
+		}
+		result.ActiveHub = hub
+	}
+
+	return result, nil
 }
 
 // GetUserRole returns the roles associated with a user.

--- a/internal/usecase/impl/profile_service.go
+++ b/internal/usecase/impl/profile_service.go
@@ -207,65 +207,7 @@ func (srv *profileService) UpdateMerchantDiscoveryProfile(ctx context.Context, u
 	var result *usecase.MerchantDiscoveryProfileResult
 
 	err := srv.txManager.Execute(ctx, func(repoFactory repository.RepositoryFactory) error {
-		userRepo := repoFactory.UserRepo()
-		discoveryRepo := repoFactory.DiscoveryRepo()
-		addressRepo := repoFactory.AddressRepo()
-
-		user, err := userRepo.FindByID(ctx, userID)
-		if err != nil {
-			if errors.Is(err, domainerrors.ErrUserNotFound) {
-				return domainerrors.ErrNotFound
-			}
-
-			return err
-		}
-		if user.MerchantProfile == nil {
-			return domainerrors.ErrValidationFailed.WithDetails("user does not have a merchant profile")
-		}
-
-		profile := user.MerchantProfile
-		categoryID := profile.DiscoveryCategoryID
-		subcategoryID := profile.DiscoverySubcategoryID
-		hubID := profile.ActiveHubID
-		isPublic := profile.IsPublic
-
-		if input.DiscoveryCategoryID.IsSet {
-			categoryID = input.DiscoveryCategoryID.Value
-		}
-		if input.DiscoverySubcategoryID.IsSet {
-			subcategoryID = input.DiscoverySubcategoryID.Value
-		}
-		if input.ActiveHubID.IsSet {
-			hubID = input.ActiveHubID.Value
-		}
-		if input.IsPublic != nil {
-			isPublic = *input.IsPublic
-		}
-
-		if err := validateMerchantDiscoveryUpdateValues(ctx, discoveryRepo, input, categoryID, subcategoryID, hubID, isPublic); err != nil {
-			return err
-		}
-
-		hasActivePrimaryLocation, err := merchantHasActivePrimaryLocation(ctx, addressRepo, userID)
-		if err != nil {
-			return err
-		}
-		if isPublic {
-			if err := validateMerchantDiscoveryEligibility(profile, categoryID, subcategoryID, hasActivePrimaryLocation); err != nil {
-				return err
-			}
-		}
-
-		profile.DiscoveryCategoryID = categoryID
-		profile.DiscoverySubcategoryID = subcategoryID
-		profile.ActiveHubID = hubID
-		profile.IsPublic = isPublic
-
-		if err := userRepo.Update(ctx, user); err != nil {
-			return err
-		}
-
-		resolved, err := buildMerchantDiscoveryProfileResult(ctx, discoveryRepo, profile, hasActivePrimaryLocation)
+		resolved, err := updateMerchantDiscoveryProfile(ctx, repoFactory, userID, input)
 		if err != nil {
 			return err
 		}
@@ -278,6 +220,118 @@ func (srv *profileService) UpdateMerchantDiscoveryProfile(ctx context.Context, u
 	}
 
 	return result, nil
+}
+
+type merchantDiscoveryProfileUpdate struct {
+	categoryID    *uuid.UUID
+	subcategoryID *uuid.UUID
+	hubID         *uuid.UUID
+	isPublic      bool
+}
+
+func updateMerchantDiscoveryProfile(
+	ctx context.Context,
+	repoFactory repository.RepositoryFactory,
+	userID uuid.UUID,
+	input *usecase.UpdateMerchantDiscoveryProfileInput,
+) (*usecase.MerchantDiscoveryProfileResult, error) {
+	userRepo := repoFactory.UserRepo()
+	discoveryRepo := repoFactory.DiscoveryRepo()
+	addressRepo := repoFactory.AddressRepo()
+
+	user, profile, err := findMerchantProfileForUpdate(ctx, userRepo, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	update := buildMerchantDiscoveryProfileUpdate(profile, input)
+	if err := validateMerchantDiscoveryUpdateValues(ctx, discoveryRepo, input, update); err != nil {
+		return nil, err
+	}
+
+	hasActivePrimaryLocation, err := merchantHasActivePrimaryLocation(ctx, addressRepo, userID)
+	if err != nil {
+		return nil, err
+	}
+	if err := validatePublicMerchantDiscoveryUpdate(profile, update, hasActivePrimaryLocation); err != nil {
+		return nil, err
+	}
+
+	applyMerchantDiscoveryProfileUpdate(profile, update)
+	if err := userRepo.Update(ctx, user); err != nil {
+		return nil, err
+	}
+
+	return buildMerchantDiscoveryProfileResult(ctx, discoveryRepo, profile, hasActivePrimaryLocation)
+}
+
+func findMerchantProfileForUpdate(
+	ctx context.Context,
+	userRepo repository.UserRepository,
+	userID uuid.UUID,
+) (*entity.User, *entity.MerchantProfile, error) {
+	user, err := userRepo.FindByID(ctx, userID)
+	if err != nil {
+		if errors.Is(err, domainerrors.ErrUserNotFound) {
+			return nil, nil, domainerrors.ErrNotFound
+		}
+
+		return nil, nil, err
+	}
+	if user.MerchantProfile == nil {
+		return nil, nil, domainerrors.ErrValidationFailed.WithDetails("user does not have a merchant profile")
+	}
+
+	return user, user.MerchantProfile, nil
+}
+
+func buildMerchantDiscoveryProfileUpdate(
+	profile *entity.MerchantProfile,
+	input *usecase.UpdateMerchantDiscoveryProfileInput,
+) merchantDiscoveryProfileUpdate {
+	update := merchantDiscoveryProfileUpdate{
+		categoryID:    profile.DiscoveryCategoryID,
+		subcategoryID: profile.DiscoverySubcategoryID,
+		hubID:         profile.ActiveHubID,
+		isPublic:      profile.IsPublic,
+	}
+
+	if input.DiscoveryCategoryID.IsSet {
+		update.categoryID = input.DiscoveryCategoryID.Value
+	}
+	if input.DiscoverySubcategoryID.IsSet {
+		update.subcategoryID = input.DiscoverySubcategoryID.Value
+	}
+	if input.ActiveHubID.IsSet {
+		update.hubID = input.ActiveHubID.Value
+	}
+	if input.IsPublic != nil {
+		update.isPublic = *input.IsPublic
+	}
+
+	return update
+}
+
+func validatePublicMerchantDiscoveryUpdate(
+	profile *entity.MerchantProfile,
+	update merchantDiscoveryProfileUpdate,
+	hasActivePrimaryLocation bool,
+) error {
+	if !update.isPublic {
+		return nil
+	}
+
+	return validateMerchantDiscoveryEligibility(profile, update.categoryID, update.subcategoryID, hasActivePrimaryLocation)
+}
+
+func applyMerchantDiscoveryProfileUpdate(
+	profile *entity.MerchantProfile,
+	update merchantDiscoveryProfileUpdate,
+) {
+	profile.DiscoveryCategoryID = update.categoryID
+	profile.DiscoverySubcategoryID = update.subcategoryID
+	profile.ActiveHubID = update.hubID
+	profile.IsPublic = update.isPublic
 }
 
 func (srv *profileService) SubmitMerchantVerification(ctx context.Context, userID uuid.UUID, input *usecase.SubmitMerchantVerificationInput) error {
@@ -386,40 +440,22 @@ func validateMerchantDiscoveryValues(
 ) error {
 	var category *entity.DiscoveryCategory
 	if categoryID != nil {
-		foundCategory, err := discoveryRepo.FindCategoryByID(ctx, *categoryID)
+		foundCategory, err := validateActiveDiscoveryCategory(ctx, discoveryRepo, *categoryID)
 		if err != nil {
 			return err
-		}
-		if foundCategory.Status != entity.DiscoveryStatusActive {
-			return domainerrors.ErrValidationFailed.WithDetails("discovery_category_id must reference an active category")
 		}
 		category = foundCategory
 	}
 
 	if subcategoryID != nil {
-		if category == nil {
-			return domainerrors.ErrValidationFailed.WithDetails("discovery_subcategory_id requires discovery_category_id")
-		}
-
-		subcategory, err := discoveryRepo.FindSubcategoryByID(ctx, *subcategoryID)
-		if err != nil {
+		if err := validateRequiredActiveDiscoverySubcategory(ctx, discoveryRepo, category, *subcategoryID); err != nil {
 			return err
-		}
-		if subcategory.Status != entity.DiscoveryStatusActive {
-			return domainerrors.ErrValidationFailed.WithDetails("discovery_subcategory_id must reference an active subcategory")
-		}
-		if subcategory.CategoryID != category.ID {
-			return domainerrors.ErrValidationFailed.WithDetails("discovery_subcategory_id must belong to discovery_category_id")
 		}
 	}
 
 	if hubID != nil {
-		hub, err := discoveryRepo.FindHubByID(ctx, *hubID)
-		if err != nil {
+		if err := validateActiveHub(ctx, discoveryRepo, *hubID); err != nil {
 			return err
-		}
-		if hub.Status != entity.DiscoveryStatusActive {
-			return domainerrors.ErrValidationFailed.WithDetails("active_hub_id must reference an active hub")
 		}
 	}
 
@@ -430,81 +466,184 @@ func validateMerchantDiscoveryUpdateValues(
 	ctx context.Context,
 	discoveryRepo repository.DiscoveryRepository,
 	input *usecase.UpdateMerchantDiscoveryProfileInput,
-	categoryID *uuid.UUID,
-	subcategoryID *uuid.UUID,
-	hubID *uuid.UUID,
-	isPublic bool,
+	update merchantDiscoveryProfileUpdate,
 ) error {
-	if isPublic {
-		return validateMerchantDiscoveryValues(ctx, discoveryRepo, categoryID, subcategoryID, hubID)
+	if update.isPublic {
+		return validateMerchantDiscoveryValues(ctx, discoveryRepo, update.categoryID, update.subcategoryID, update.hubID)
 	}
 
-	return validateSelectedMerchantDiscoveryValues(ctx, discoveryRepo, input, categoryID, subcategoryID, hubID)
+	return validateSelectedMerchantDiscoveryValues(ctx, discoveryRepo, input, update)
 }
 
 func validateSelectedMerchantDiscoveryValues(
 	ctx context.Context,
 	discoveryRepo repository.DiscoveryRepository,
 	input *usecase.UpdateMerchantDiscoveryProfileInput,
-	categoryID *uuid.UUID,
-	subcategoryID *uuid.UUID,
-	hubID *uuid.UUID,
+	update merchantDiscoveryProfileUpdate,
 ) error {
-	if input.DiscoveryCategoryID.IsSet && categoryID != nil {
-		category, err := discoveryRepo.FindCategoryByID(ctx, *categoryID)
-		if err != nil {
-			return err
-		}
-		if category.Status != entity.DiscoveryStatusActive {
-			return domainerrors.ErrValidationFailed.WithDetails("discovery_category_id must reference an active category")
-		}
+	if err := validateSelectedDiscoveryCategory(ctx, discoveryRepo, input, update.categoryID); err != nil {
+		return err
 	}
-
-	if input.DiscoverySubcategoryID.IsSet && subcategoryID != nil {
-		if categoryID == nil {
-			return domainerrors.ErrValidationFailed.WithDetails("discovery_subcategory_id requires discovery_category_id")
-		}
-
-		subcategory, err := discoveryRepo.FindSubcategoryByID(ctx, *subcategoryID)
-		if err != nil {
-			return err
-		}
-		if subcategory.Status != entity.DiscoveryStatusActive {
-			return domainerrors.ErrValidationFailed.WithDetails("discovery_subcategory_id must reference an active subcategory")
-		}
-		if subcategory.CategoryID != *categoryID {
-			return domainerrors.ErrValidationFailed.WithDetails("discovery_subcategory_id must belong to discovery_category_id")
-		}
+	if err := validateSelectedDiscoverySubcategory(ctx, discoveryRepo, input, update); err != nil {
+		return err
 	}
-
-	// Category changed in this PATCH but subcategory was kept. Re-verify the
-	// kept subcategory still belongs to the new category without requiring it
-	// to be active while the merchant remains private.
-	if input.DiscoveryCategoryID.IsSet && !input.DiscoverySubcategoryID.IsSet && subcategoryID != nil {
-		if categoryID == nil {
-			return domainerrors.ErrValidationFailed.WithDetails("discovery_subcategory_id requires discovery_category_id")
-		}
-
-		subcategory, err := discoveryRepo.FindSubcategoryByID(ctx, *subcategoryID)
-		if err != nil {
-			return err
-		}
-		if subcategory.CategoryID != *categoryID {
-			return domainerrors.ErrValidationFailed.WithDetails("discovery_subcategory_id must belong to discovery_category_id")
-		}
+	if err := validateRetainedDiscoverySubcategory(ctx, discoveryRepo, input, update); err != nil {
+		return err
 	}
-
-	if input.ActiveHubID.IsSet && hubID != nil {
-		hub, err := discoveryRepo.FindHubByID(ctx, *hubID)
-		if err != nil {
-			return err
-		}
-		if hub.Status != entity.DiscoveryStatusActive {
-			return domainerrors.ErrValidationFailed.WithDetails("active_hub_id must reference an active hub")
-		}
+	if err := validateSelectedHub(ctx, discoveryRepo, input, update.hubID); err != nil {
+		return err
 	}
 
 	return nil
+}
+
+func validateActiveDiscoveryCategory(
+	ctx context.Context,
+	discoveryRepo repository.DiscoveryRepository,
+	categoryID uuid.UUID,
+) (*entity.DiscoveryCategory, error) {
+	category, err := discoveryRepo.FindCategoryByID(ctx, categoryID)
+	if err != nil {
+		return nil, err
+	}
+	if category.Status != entity.DiscoveryStatusActive {
+		return nil, domainerrors.ErrValidationFailed.WithDetails("discovery_category_id must reference an active category")
+	}
+
+	return category, nil
+}
+
+func validateRequiredActiveDiscoverySubcategory(
+	ctx context.Context,
+	discoveryRepo repository.DiscoveryRepository,
+	category *entity.DiscoveryCategory,
+	subcategoryID uuid.UUID,
+) error {
+	if category == nil {
+		return domainerrors.ErrValidationFailed.WithDetails("discovery_subcategory_id requires discovery_category_id")
+	}
+
+	return validateActiveDiscoverySubcategory(ctx, discoveryRepo, category.ID, subcategoryID)
+}
+
+func validateActiveDiscoverySubcategory(
+	ctx context.Context,
+	discoveryRepo repository.DiscoveryRepository,
+	categoryID uuid.UUID,
+	subcategoryID uuid.UUID,
+) error {
+	subcategory, err := discoveryRepo.FindSubcategoryByID(ctx, subcategoryID)
+	if err != nil {
+		return err
+	}
+	if subcategory.Status != entity.DiscoveryStatusActive {
+		return domainerrors.ErrValidationFailed.WithDetails("discovery_subcategory_id must reference an active subcategory")
+	}
+	if subcategory.CategoryID != categoryID {
+		return domainerrors.ErrValidationFailed.WithDetails("discovery_subcategory_id must belong to discovery_category_id")
+	}
+
+	return nil
+}
+
+func validateActiveHub(
+	ctx context.Context,
+	discoveryRepo repository.DiscoveryRepository,
+	hubID uuid.UUID,
+) error {
+	hub, err := discoveryRepo.FindHubByID(ctx, hubID)
+	if err != nil {
+		return err
+	}
+	if hub.Status != entity.DiscoveryStatusActive {
+		return domainerrors.ErrValidationFailed.WithDetails("active_hub_id must reference an active hub")
+	}
+
+	return nil
+}
+
+func validateSelectedDiscoveryCategory(
+	ctx context.Context,
+	discoveryRepo repository.DiscoveryRepository,
+	input *usecase.UpdateMerchantDiscoveryProfileInput,
+	categoryID *uuid.UUID,
+) error {
+	if !input.DiscoveryCategoryID.IsSet || categoryID == nil {
+		return nil
+	}
+
+	_, err := validateActiveDiscoveryCategory(ctx, discoveryRepo, *categoryID)
+
+	return err
+}
+
+func validateSelectedDiscoverySubcategory(
+	ctx context.Context,
+	discoveryRepo repository.DiscoveryRepository,
+	input *usecase.UpdateMerchantDiscoveryProfileInput,
+	update merchantDiscoveryProfileUpdate,
+) error {
+	if !input.DiscoverySubcategoryID.IsSet || update.subcategoryID == nil {
+		return nil
+	}
+	if update.categoryID == nil {
+		return domainerrors.ErrValidationFailed.WithDetails("discovery_subcategory_id requires discovery_category_id")
+	}
+
+	return validateActiveDiscoverySubcategory(ctx, discoveryRepo, *update.categoryID, *update.subcategoryID)
+}
+
+func validateRetainedDiscoverySubcategory(
+	ctx context.Context,
+	discoveryRepo repository.DiscoveryRepository,
+	input *usecase.UpdateMerchantDiscoveryProfileInput,
+	update merchantDiscoveryProfileUpdate,
+) error {
+	if !shouldValidateRetainedDiscoverySubcategory(input, update.subcategoryID) {
+		return nil
+	}
+	if update.categoryID == nil {
+		return domainerrors.ErrValidationFailed.WithDetails("discovery_subcategory_id requires discovery_category_id")
+	}
+
+	return validateDiscoverySubcategoryCategory(ctx, discoveryRepo, *update.categoryID, *update.subcategoryID)
+}
+
+func shouldValidateRetainedDiscoverySubcategory(
+	input *usecase.UpdateMerchantDiscoveryProfileInput,
+	subcategoryID *uuid.UUID,
+) bool {
+	return input.DiscoveryCategoryID.IsSet && !input.DiscoverySubcategoryID.IsSet && subcategoryID != nil
+}
+
+func validateDiscoverySubcategoryCategory(
+	ctx context.Context,
+	discoveryRepo repository.DiscoveryRepository,
+	categoryID uuid.UUID,
+	subcategoryID uuid.UUID,
+) error {
+	subcategory, err := discoveryRepo.FindSubcategoryByID(ctx, subcategoryID)
+	if err != nil {
+		return err
+	}
+	if subcategory.CategoryID != categoryID {
+		return domainerrors.ErrValidationFailed.WithDetails("discovery_subcategory_id must belong to discovery_category_id")
+	}
+
+	return nil
+}
+
+func validateSelectedHub(
+	ctx context.Context,
+	discoveryRepo repository.DiscoveryRepository,
+	input *usecase.UpdateMerchantDiscoveryProfileInput,
+	hubID *uuid.UUID,
+) error {
+	if !input.ActiveHubID.IsSet || hubID == nil {
+		return nil
+	}
+
+	return validateActiveHub(ctx, discoveryRepo, *hubID)
 }
 
 func validateMerchantDiscoveryEligibility(
@@ -534,17 +673,19 @@ func merchantHasActivePrimaryLocation(
 	addressRepo repository.AddressRepository,
 	merchantID uuid.UUID,
 ) (bool, error) {
-	addresses, err := addressRepo.FindActiveAddressesByOwner(ctx, merchantID, entity.OwnerTypeMerchantProfile)
+	address, err := addressRepo.FindPrimaryAddressByOwner(ctx, merchantID, entity.OwnerTypeMerchantProfile)
 	if err != nil {
+		if errors.Is(err, domainerrors.ErrAddressNotFound) {
+			return false, nil
+		}
+
 		return false, err
 	}
-	for _, address := range addresses {
-		if address.IsPrimary {
-			return true, nil
-		}
+	if address == nil {
+		return false, nil
 	}
 
-	return false, nil
+	return address.IsActive, nil
 }
 
 func buildMerchantDiscoveryProfileResult(

--- a/internal/usecase/impl/profile_service_discovery_test.go
+++ b/internal/usecase/impl/profile_service_discovery_test.go
@@ -65,8 +65,8 @@ func TestProfileService_GetMerchantDiscoveryProfile_Success(t *testing.T) {
 		factory.EXPECT().AddressRepo().Return(mockAddressRepo)
 		mockUserRepo.EXPECT().FindByID(ctx, userID).Return(user, nil)
 		mockAddressRepo.EXPECT().
-			FindActiveAddressesByOwner(ctx, userID, entity.OwnerTypeMerchantProfile).
-			Return([]*entity.Address{{ID: uuid.New(), OwnerID: userID, OwnerType: entity.OwnerTypeMerchantProfile, IsPrimary: true, IsActive: true}}, nil)
+			FindPrimaryAddressByOwner(ctx, userID, entity.OwnerTypeMerchantProfile).
+			Return(&entity.Address{ID: uuid.New(), OwnerID: userID, OwnerType: entity.OwnerTypeMerchantProfile, IsPrimary: true, IsActive: true}, nil)
 		mockDiscoveryRepo.EXPECT().FindCategoryByID(ctx, categoryID).Return(category, nil)
 		mockDiscoveryRepo.EXPECT().FindSubcategoryByID(ctx, subcategoryID).Return(subcategory, nil)
 		mockDiscoveryRepo.EXPECT().FindHubByID(ctx, hubID).Return(hub, nil)
@@ -124,8 +124,8 @@ func TestProfileService_UpdateMerchantDiscoveryProfile_EnablePublicSuccess(t *te
 		mockDiscoveryRepo.EXPECT().FindSubcategoryByID(ctx, subcategoryID).Return(subcategory, nil).Twice()
 		mockDiscoveryRepo.EXPECT().FindHubByID(ctx, hubID).Return(hub, nil).Twice()
 		mockAddressRepo.EXPECT().
-			FindActiveAddressesByOwner(ctx, userID, entity.OwnerTypeMerchantProfile).
-			Return([]*entity.Address{{ID: uuid.New(), OwnerID: userID, OwnerType: entity.OwnerTypeMerchantProfile, IsPrimary: true, IsActive: true}}, nil)
+			FindPrimaryAddressByOwner(ctx, userID, entity.OwnerTypeMerchantProfile).
+			Return(&entity.Address{ID: uuid.New(), OwnerID: userID, OwnerType: entity.OwnerTypeMerchantProfile, IsPrimary: true, IsActive: true}, nil)
 		mockUserRepo.EXPECT().
 			Update(ctx, mock.AnythingOfType("*entity.User")).
 			Run(func(_ context.Context, updated *entity.User) {
@@ -176,8 +176,8 @@ func TestProfileService_UpdateMerchantDiscoveryProfile_ClearActiveHub(t *testing
 		factory.EXPECT().AddressRepo().Return(mockAddressRepo)
 		mockUserRepo.EXPECT().FindByID(ctx, userID).Return(user, nil)
 		mockAddressRepo.EXPECT().
-			FindActiveAddressesByOwner(ctx, userID, entity.OwnerTypeMerchantProfile).
-			Return(nil, nil)
+			FindPrimaryAddressByOwner(ctx, userID, entity.OwnerTypeMerchantProfile).
+			Return(nil, domainerrors.ErrAddressNotFound)
 		mockUserRepo.EXPECT().
 			Update(ctx, mock.AnythingOfType("*entity.User")).
 			Run(func(_ context.Context, updated *entity.User) {
@@ -228,8 +228,8 @@ func TestProfileService_UpdateMerchantDiscoveryProfile_AllowsDisablingPublicWith
 		factory.EXPECT().AddressRepo().Return(mockAddressRepo)
 		mockUserRepo.EXPECT().FindByID(ctx, userID).Return(user, nil)
 		mockAddressRepo.EXPECT().
-			FindActiveAddressesByOwner(ctx, userID, entity.OwnerTypeMerchantProfile).
-			Return(nil, nil)
+			FindPrimaryAddressByOwner(ctx, userID, entity.OwnerTypeMerchantProfile).
+			Return(nil, domainerrors.ErrAddressNotFound)
 		updateCall := mockUserRepo.EXPECT().
 			Update(ctx, mock.AnythingOfType("*entity.User")).
 			Run(func(_ context.Context, updated *entity.User) {
@@ -376,8 +376,8 @@ func TestProfileService_UpdateMerchantDiscoveryProfile_RejectsUnverifiedPublicMe
 			FindSubcategoryByID(ctx, subcategoryID).
 			Return(&entity.DiscoverySubcategory{ID: subcategoryID, CategoryID: categoryID, Status: entity.DiscoveryStatusActive}, nil)
 		mockAddressRepo.EXPECT().
-			FindActiveAddressesByOwner(ctx, userID, entity.OwnerTypeMerchantProfile).
-			Return([]*entity.Address{{ID: uuid.New(), OwnerID: userID, OwnerType: entity.OwnerTypeMerchantProfile, IsPrimary: true, IsActive: true}}, nil)
+			FindPrimaryAddressByOwner(ctx, userID, entity.OwnerTypeMerchantProfile).
+			Return(&entity.Address{ID: uuid.New(), OwnerID: userID, OwnerType: entity.OwnerTypeMerchantProfile, IsPrimary: true, IsActive: true}, nil)
 	})
 
 	_, err := fx.service.UpdateMerchantDiscoveryProfile(ctx, userID, input)
@@ -422,8 +422,8 @@ func TestProfileService_UpdateMerchantDiscoveryProfile_RejectsPublicWithoutActiv
 			FindSubcategoryByID(ctx, subcategoryID).
 			Return(&entity.DiscoverySubcategory{ID: subcategoryID, CategoryID: categoryID, Status: entity.DiscoveryStatusActive}, nil)
 		mockAddressRepo.EXPECT().
-			FindActiveAddressesByOwner(ctx, userID, entity.OwnerTypeMerchantProfile).
-			Return(nil, nil)
+			FindPrimaryAddressByOwner(ctx, userID, entity.OwnerTypeMerchantProfile).
+			Return(&entity.Address{ID: uuid.New(), OwnerID: userID, OwnerType: entity.OwnerTypeMerchantProfile, IsPrimary: true, IsActive: false}, nil)
 	})
 
 	_, err := fx.service.UpdateMerchantDiscoveryProfile(ctx, userID, input)

--- a/internal/usecase/impl/profile_service_discovery_test.go
+++ b/internal/usecase/impl/profile_service_discovery_test.go
@@ -1,0 +1,466 @@
+package impl
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"radar/internal/domain/entity"
+	domainerrors "radar/internal/domain/errors"
+	"radar/internal/domain/repository"
+	mockRepo "radar/internal/mocks/repository"
+	"radar/internal/usecase"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func executeProfileDiscoveryTx(
+	t *testing.T,
+	fx *profileServiceFixtures,
+	ctx context.Context,
+	setupMocks func(factory *mockRepo.MockRepositoryFactory),
+) {
+	fx.txManager.EXPECT().
+		Execute(ctx, mock.AnythingOfType("func(repository.RepositoryFactory) error")).
+		RunAndReturn(func(ctx context.Context, fn func(repository.RepositoryFactory) error) error {
+			mockFactory := mockRepo.NewMockRepositoryFactory(t)
+			setupMocks(mockFactory)
+
+			return fn(mockFactory)
+		})
+}
+
+func TestProfileService_GetMerchantDiscoveryProfile_Success(t *testing.T) {
+	fx := createTestProfileService(t)
+
+	ctx := context.Background()
+	userID := uuid.New()
+	categoryID := uuid.New()
+	subcategoryID := uuid.New()
+	hubID := uuid.New()
+	category := &entity.DiscoveryCategory{ID: categoryID, Slug: "meal", Status: entity.DiscoveryStatusActive}
+	subcategory := &entity.DiscoverySubcategory{ID: subcategoryID, CategoryID: categoryID, Slug: "grill", Status: entity.DiscoveryStatusActive}
+	hub := &entity.Hub{ID: hubID, Slug: "night-market", Status: entity.DiscoveryStatusActive}
+	user := &entity.User{
+		ID: userID,
+		MerchantProfile: &entity.MerchantProfile{
+			UserID:                 userID,
+			VerificationStatus:     entity.MerchantVerificationStatusVerified,
+			DiscoveryCategoryID:    &categoryID,
+			DiscoverySubcategoryID: &subcategoryID,
+			ActiveHubID:            &hubID,
+			IsPublic:               true,
+		},
+	}
+
+	executeProfileDiscoveryTx(t, fx, ctx, func(factory *mockRepo.MockRepositoryFactory) {
+		mockUserRepo := mockRepo.NewMockUserRepository(t)
+		mockDiscoveryRepo := mockRepo.NewMockDiscoveryRepository(t)
+		mockAddressRepo := mockRepo.NewMockAddressRepository(t)
+		factory.EXPECT().UserRepo().Return(mockUserRepo)
+		factory.EXPECT().DiscoveryRepo().Return(mockDiscoveryRepo)
+		factory.EXPECT().AddressRepo().Return(mockAddressRepo)
+		mockUserRepo.EXPECT().FindByID(ctx, userID).Return(user, nil)
+		mockAddressRepo.EXPECT().
+			FindActiveAddressesByOwner(ctx, userID, entity.OwnerTypeMerchantProfile).
+			Return([]*entity.Address{{ID: uuid.New(), OwnerID: userID, OwnerType: entity.OwnerTypeMerchantProfile, IsPrimary: true, IsActive: true}}, nil)
+		mockDiscoveryRepo.EXPECT().FindCategoryByID(ctx, categoryID).Return(category, nil)
+		mockDiscoveryRepo.EXPECT().FindSubcategoryByID(ctx, subcategoryID).Return(subcategory, nil)
+		mockDiscoveryRepo.EXPECT().FindHubByID(ctx, hubID).Return(hub, nil)
+	})
+
+	result, err := fx.service.GetMerchantDiscoveryProfile(ctx, userID)
+
+	require.NoError(t, err)
+	assert.Equal(t, &categoryID, result.DiscoveryCategoryID)
+	assert.Equal(t, &subcategoryID, result.DiscoverySubcategoryID)
+	assert.Equal(t, &hubID, result.ActiveHubID)
+	assert.True(t, result.IsPublic)
+	assert.True(t, result.IsVerified)
+	assert.True(t, result.HasActivePrimaryLocation)
+	assert.Equal(t, category, result.DiscoveryCategory)
+	assert.Equal(t, subcategory, result.DiscoverySubcategory)
+	assert.Equal(t, hub, result.ActiveHub)
+}
+
+func TestProfileService_UpdateMerchantDiscoveryProfile_EnablePublicSuccess(t *testing.T) {
+	fx := createTestProfileService(t)
+
+	ctx := context.Background()
+	userID := uuid.New()
+	categoryID := uuid.New()
+	subcategoryID := uuid.New()
+	hubID := uuid.New()
+	isPublic := true
+	category := &entity.DiscoveryCategory{ID: categoryID, Slug: "meal", Status: entity.DiscoveryStatusActive}
+	subcategory := &entity.DiscoverySubcategory{ID: subcategoryID, CategoryID: categoryID, Slug: "grill", Status: entity.DiscoveryStatusActive}
+	hub := &entity.Hub{ID: hubID, Slug: "night-market", Status: entity.DiscoveryStatusActive}
+	user := &entity.User{
+		ID: userID,
+		MerchantProfile: &entity.MerchantProfile{
+			UserID:             userID,
+			VerificationStatus: entity.MerchantVerificationStatusVerified,
+		},
+	}
+	input := &usecase.UpdateMerchantDiscoveryProfileInput{
+		DiscoveryCategoryID:    usecase.OptionalUUIDUpdate{IsSet: true, Value: &categoryID},
+		DiscoverySubcategoryID: usecase.OptionalUUIDUpdate{IsSet: true, Value: &subcategoryID},
+		ActiveHubID:            usecase.OptionalUUIDUpdate{IsSet: true, Value: &hubID},
+		IsPublic:               &isPublic,
+	}
+
+	executeProfileDiscoveryTx(t, fx, ctx, func(factory *mockRepo.MockRepositoryFactory) {
+		mockUserRepo := mockRepo.NewMockUserRepository(t)
+		mockDiscoveryRepo := mockRepo.NewMockDiscoveryRepository(t)
+		mockAddressRepo := mockRepo.NewMockAddressRepository(t)
+		factory.EXPECT().UserRepo().Return(mockUserRepo)
+		factory.EXPECT().DiscoveryRepo().Return(mockDiscoveryRepo)
+		factory.EXPECT().AddressRepo().Return(mockAddressRepo)
+		mockUserRepo.EXPECT().FindByID(ctx, userID).Return(user, nil)
+		mockDiscoveryRepo.EXPECT().FindCategoryByID(ctx, categoryID).Return(category, nil).Twice()
+		mockDiscoveryRepo.EXPECT().FindSubcategoryByID(ctx, subcategoryID).Return(subcategory, nil).Twice()
+		mockDiscoveryRepo.EXPECT().FindHubByID(ctx, hubID).Return(hub, nil).Twice()
+		mockAddressRepo.EXPECT().
+			FindActiveAddressesByOwner(ctx, userID, entity.OwnerTypeMerchantProfile).
+			Return([]*entity.Address{{ID: uuid.New(), OwnerID: userID, OwnerType: entity.OwnerTypeMerchantProfile, IsPrimary: true, IsActive: true}}, nil)
+		mockUserRepo.EXPECT().
+			Update(ctx, mock.AnythingOfType("*entity.User")).
+			Run(func(_ context.Context, updated *entity.User) {
+				assert.Equal(t, &categoryID, updated.MerchantProfile.DiscoveryCategoryID)
+				assert.Equal(t, &subcategoryID, updated.MerchantProfile.DiscoverySubcategoryID)
+				assert.Equal(t, &hubID, updated.MerchantProfile.ActiveHubID)
+				assert.True(t, updated.MerchantProfile.IsPublic)
+			}).
+			Return(nil)
+	})
+
+	result, err := fx.service.UpdateMerchantDiscoveryProfile(ctx, userID, input)
+
+	require.NoError(t, err)
+	assert.True(t, result.IsPublic)
+	assert.Equal(t, category, result.DiscoveryCategory)
+	assert.Equal(t, subcategory, result.DiscoverySubcategory)
+	assert.Equal(t, hub, result.ActiveHub)
+}
+
+func TestProfileService_UpdateMerchantDiscoveryProfile_ClearActiveHub(t *testing.T) {
+	fx := createTestProfileService(t)
+
+	ctx := context.Background()
+	userID := uuid.New()
+	hubID := uuid.New()
+	isPublic := false
+	user := &entity.User{
+		ID: userID,
+		MerchantProfile: &entity.MerchantProfile{
+			UserID:             userID,
+			VerificationStatus: entity.MerchantVerificationStatusUnverified,
+			ActiveHubID:        &hubID,
+			IsPublic:           true,
+		},
+	}
+	input := &usecase.UpdateMerchantDiscoveryProfileInput{
+		ActiveHubID: usecase.OptionalUUIDUpdate{IsSet: true, Value: nil},
+		IsPublic:    &isPublic,
+	}
+
+	executeProfileDiscoveryTx(t, fx, ctx, func(factory *mockRepo.MockRepositoryFactory) {
+		mockUserRepo := mockRepo.NewMockUserRepository(t)
+		mockDiscoveryRepo := mockRepo.NewMockDiscoveryRepository(t)
+		mockAddressRepo := mockRepo.NewMockAddressRepository(t)
+		factory.EXPECT().UserRepo().Return(mockUserRepo)
+		factory.EXPECT().DiscoveryRepo().Return(mockDiscoveryRepo)
+		factory.EXPECT().AddressRepo().Return(mockAddressRepo)
+		mockUserRepo.EXPECT().FindByID(ctx, userID).Return(user, nil)
+		mockAddressRepo.EXPECT().
+			FindActiveAddressesByOwner(ctx, userID, entity.OwnerTypeMerchantProfile).
+			Return(nil, nil)
+		mockUserRepo.EXPECT().
+			Update(ctx, mock.AnythingOfType("*entity.User")).
+			Run(func(_ context.Context, updated *entity.User) {
+				assert.Nil(t, updated.MerchantProfile.ActiveHubID)
+				assert.False(t, updated.MerchantProfile.IsPublic)
+			}).
+			Return(nil)
+	})
+
+	result, err := fx.service.UpdateMerchantDiscoveryProfile(ctx, userID, input)
+
+	require.NoError(t, err)
+	assert.Nil(t, result.ActiveHubID)
+	assert.False(t, result.IsPublic)
+	assert.False(t, result.HasActivePrimaryLocation)
+}
+
+func TestProfileService_UpdateMerchantDiscoveryProfile_AllowsDisablingPublicWithInactiveExistingValues(t *testing.T) {
+	fx := createTestProfileService(t)
+
+	ctx := context.Background()
+	userID := uuid.New()
+	categoryID := uuid.New()
+	subcategoryID := uuid.New()
+	hubID := uuid.New()
+	isPublic := false
+	user := &entity.User{
+		ID: userID,
+		MerchantProfile: &entity.MerchantProfile{
+			UserID:                 userID,
+			VerificationStatus:     entity.MerchantVerificationStatusVerified,
+			DiscoveryCategoryID:    &categoryID,
+			DiscoverySubcategoryID: &subcategoryID,
+			ActiveHubID:            &hubID,
+			IsPublic:               true,
+		},
+	}
+	input := &usecase.UpdateMerchantDiscoveryProfileInput{
+		IsPublic: &isPublic,
+	}
+
+	executeProfileDiscoveryTx(t, fx, ctx, func(factory *mockRepo.MockRepositoryFactory) {
+		mockUserRepo := mockRepo.NewMockUserRepository(t)
+		mockDiscoveryRepo := mockRepo.NewMockDiscoveryRepository(t)
+		mockAddressRepo := mockRepo.NewMockAddressRepository(t)
+		factory.EXPECT().UserRepo().Return(mockUserRepo)
+		factory.EXPECT().DiscoveryRepo().Return(mockDiscoveryRepo)
+		factory.EXPECT().AddressRepo().Return(mockAddressRepo)
+		mockUserRepo.EXPECT().FindByID(ctx, userID).Return(user, nil)
+		mockAddressRepo.EXPECT().
+			FindActiveAddressesByOwner(ctx, userID, entity.OwnerTypeMerchantProfile).
+			Return(nil, nil)
+		updateCall := mockUserRepo.EXPECT().
+			Update(ctx, mock.AnythingOfType("*entity.User")).
+			Run(func(_ context.Context, updated *entity.User) {
+				assert.False(t, updated.MerchantProfile.IsPublic)
+			}).
+			Return(nil)
+		mockDiscoveryRepo.EXPECT().
+			FindCategoryByID(ctx, categoryID).
+			Return(&entity.DiscoveryCategory{ID: categoryID, Status: entity.DiscoveryStatusInactive}, nil).
+			NotBefore(updateCall.Call)
+		mockDiscoveryRepo.EXPECT().
+			FindSubcategoryByID(ctx, subcategoryID).
+			Return(&entity.DiscoverySubcategory{ID: subcategoryID, CategoryID: categoryID, Status: entity.DiscoveryStatusInactive}, nil).
+			NotBefore(updateCall.Call)
+		mockDiscoveryRepo.EXPECT().
+			FindHubByID(ctx, hubID).
+			Return(&entity.Hub{ID: hubID, Status: entity.DiscoveryStatusInactive}, nil).
+			NotBefore(updateCall.Call)
+	})
+
+	result, err := fx.service.UpdateMerchantDiscoveryProfile(ctx, userID, input)
+
+	require.NoError(t, err)
+	assert.False(t, result.IsPublic)
+	assert.Equal(t, entity.DiscoveryStatusInactive, result.DiscoveryCategory.Status)
+	assert.Equal(t, entity.DiscoveryStatusInactive, result.DiscoverySubcategory.Status)
+	assert.Equal(t, entity.DiscoveryStatusInactive, result.ActiveHub.Status)
+}
+
+func TestProfileService_UpdateMerchantDiscoveryProfile_RejectsSelectedInactiveHubWhenPrivate(t *testing.T) {
+	fx := createTestProfileService(t)
+
+	ctx := context.Background()
+	userID := uuid.New()
+	hubID := uuid.New()
+	isPublic := false
+	user := &entity.User{
+		ID: userID,
+		MerchantProfile: &entity.MerchantProfile{
+			UserID:             userID,
+			VerificationStatus: entity.MerchantVerificationStatusVerified,
+		},
+	}
+	input := &usecase.UpdateMerchantDiscoveryProfileInput{
+		ActiveHubID: usecase.OptionalUUIDUpdate{IsSet: true, Value: &hubID},
+		IsPublic:    &isPublic,
+	}
+
+	executeProfileDiscoveryTx(t, fx, ctx, func(factory *mockRepo.MockRepositoryFactory) {
+		mockUserRepo := mockRepo.NewMockUserRepository(t)
+		mockDiscoveryRepo := mockRepo.NewMockDiscoveryRepository(t)
+		mockAddressRepo := mockRepo.NewMockAddressRepository(t)
+		factory.EXPECT().UserRepo().Return(mockUserRepo)
+		factory.EXPECT().DiscoveryRepo().Return(mockDiscoveryRepo)
+		factory.EXPECT().AddressRepo().Return(mockAddressRepo)
+		mockUserRepo.EXPECT().FindByID(ctx, userID).Return(user, nil)
+		mockDiscoveryRepo.EXPECT().
+			FindHubByID(ctx, hubID).
+			Return(&entity.Hub{ID: hubID, Status: entity.DiscoveryStatusInactive}, nil)
+	})
+
+	_, err := fx.service.UpdateMerchantDiscoveryProfile(ctx, userID, input)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, domainerrors.ErrValidationFailed)
+}
+
+func TestProfileService_UpdateMerchantDiscoveryProfile_RejectsMismatchedSubcategory(t *testing.T) {
+	fx := createTestProfileService(t)
+
+	ctx := context.Background()
+	userID := uuid.New()
+	categoryID := uuid.New()
+	otherCategoryID := uuid.New()
+	subcategoryID := uuid.New()
+	user := &entity.User{
+		ID: userID,
+		MerchantProfile: &entity.MerchantProfile{
+			UserID:             userID,
+			VerificationStatus: entity.MerchantVerificationStatusVerified,
+		},
+	}
+	input := &usecase.UpdateMerchantDiscoveryProfileInput{
+		DiscoveryCategoryID:    usecase.OptionalUUIDUpdate{IsSet: true, Value: &categoryID},
+		DiscoverySubcategoryID: usecase.OptionalUUIDUpdate{IsSet: true, Value: &subcategoryID},
+	}
+
+	executeProfileDiscoveryTx(t, fx, ctx, func(factory *mockRepo.MockRepositoryFactory) {
+		mockUserRepo := mockRepo.NewMockUserRepository(t)
+		mockDiscoveryRepo := mockRepo.NewMockDiscoveryRepository(t)
+		mockAddressRepo := mockRepo.NewMockAddressRepository(t)
+		factory.EXPECT().UserRepo().Return(mockUserRepo)
+		factory.EXPECT().DiscoveryRepo().Return(mockDiscoveryRepo)
+		factory.EXPECT().AddressRepo().Return(mockAddressRepo)
+		mockUserRepo.EXPECT().FindByID(ctx, userID).Return(user, nil)
+		mockDiscoveryRepo.EXPECT().
+			FindCategoryByID(ctx, categoryID).
+			Return(&entity.DiscoveryCategory{ID: categoryID, Status: entity.DiscoveryStatusActive}, nil)
+		mockDiscoveryRepo.EXPECT().
+			FindSubcategoryByID(ctx, subcategoryID).
+			Return(&entity.DiscoverySubcategory{ID: subcategoryID, CategoryID: otherCategoryID, Status: entity.DiscoveryStatusActive}, nil)
+	})
+
+	_, err := fx.service.UpdateMerchantDiscoveryProfile(ctx, userID, input)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, domainerrors.ErrValidationFailed)
+	assert.Contains(t, err.Error(), "輸入資料驗證失敗")
+}
+
+func TestProfileService_UpdateMerchantDiscoveryProfile_RejectsUnverifiedPublicMerchant(t *testing.T) {
+	fx := createTestProfileService(t)
+
+	ctx := context.Background()
+	userID := uuid.New()
+	categoryID := uuid.New()
+	subcategoryID := uuid.New()
+	isPublic := true
+	user := &entity.User{
+		ID: userID,
+		MerchantProfile: &entity.MerchantProfile{
+			UserID:             userID,
+			VerificationStatus: entity.MerchantVerificationStatusUnverified,
+		},
+	}
+	input := &usecase.UpdateMerchantDiscoveryProfileInput{
+		DiscoveryCategoryID:    usecase.OptionalUUIDUpdate{IsSet: true, Value: &categoryID},
+		DiscoverySubcategoryID: usecase.OptionalUUIDUpdate{IsSet: true, Value: &subcategoryID},
+		IsPublic:               &isPublic,
+	}
+
+	executeProfileDiscoveryTx(t, fx, ctx, func(factory *mockRepo.MockRepositoryFactory) {
+		mockUserRepo := mockRepo.NewMockUserRepository(t)
+		mockDiscoveryRepo := mockRepo.NewMockDiscoveryRepository(t)
+		mockAddressRepo := mockRepo.NewMockAddressRepository(t)
+		factory.EXPECT().UserRepo().Return(mockUserRepo)
+		factory.EXPECT().DiscoveryRepo().Return(mockDiscoveryRepo)
+		factory.EXPECT().AddressRepo().Return(mockAddressRepo)
+		mockUserRepo.EXPECT().FindByID(ctx, userID).Return(user, nil)
+		mockDiscoveryRepo.EXPECT().
+			FindCategoryByID(ctx, categoryID).
+			Return(&entity.DiscoveryCategory{ID: categoryID, Status: entity.DiscoveryStatusActive}, nil)
+		mockDiscoveryRepo.EXPECT().
+			FindSubcategoryByID(ctx, subcategoryID).
+			Return(&entity.DiscoverySubcategory{ID: subcategoryID, CategoryID: categoryID, Status: entity.DiscoveryStatusActive}, nil)
+		mockAddressRepo.EXPECT().
+			FindActiveAddressesByOwner(ctx, userID, entity.OwnerTypeMerchantProfile).
+			Return([]*entity.Address{{ID: uuid.New(), OwnerID: userID, OwnerType: entity.OwnerTypeMerchantProfile, IsPrimary: true, IsActive: true}}, nil)
+	})
+
+	_, err := fx.service.UpdateMerchantDiscoveryProfile(ctx, userID, input)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, domainerrors.ErrValidationFailed)
+}
+
+func TestProfileService_UpdateMerchantDiscoveryProfile_RejectsPublicWithoutActivePrimaryLocation(t *testing.T) {
+	fx := createTestProfileService(t)
+
+	ctx := context.Background()
+	userID := uuid.New()
+	categoryID := uuid.New()
+	subcategoryID := uuid.New()
+	isPublic := true
+	user := &entity.User{
+		ID: userID,
+		MerchantProfile: &entity.MerchantProfile{
+			UserID:             userID,
+			VerificationStatus: entity.MerchantVerificationStatusVerified,
+		},
+	}
+	input := &usecase.UpdateMerchantDiscoveryProfileInput{
+		DiscoveryCategoryID:    usecase.OptionalUUIDUpdate{IsSet: true, Value: &categoryID},
+		DiscoverySubcategoryID: usecase.OptionalUUIDUpdate{IsSet: true, Value: &subcategoryID},
+		IsPublic:               &isPublic,
+	}
+
+	executeProfileDiscoveryTx(t, fx, ctx, func(factory *mockRepo.MockRepositoryFactory) {
+		mockUserRepo := mockRepo.NewMockUserRepository(t)
+		mockDiscoveryRepo := mockRepo.NewMockDiscoveryRepository(t)
+		mockAddressRepo := mockRepo.NewMockAddressRepository(t)
+		factory.EXPECT().UserRepo().Return(mockUserRepo)
+		factory.EXPECT().DiscoveryRepo().Return(mockDiscoveryRepo)
+		factory.EXPECT().AddressRepo().Return(mockAddressRepo)
+		mockUserRepo.EXPECT().FindByID(ctx, userID).Return(user, nil)
+		mockDiscoveryRepo.EXPECT().
+			FindCategoryByID(ctx, categoryID).
+			Return(&entity.DiscoveryCategory{ID: categoryID, Status: entity.DiscoveryStatusActive}, nil)
+		mockDiscoveryRepo.EXPECT().
+			FindSubcategoryByID(ctx, subcategoryID).
+			Return(&entity.DiscoverySubcategory{ID: subcategoryID, CategoryID: categoryID, Status: entity.DiscoveryStatusActive}, nil)
+		mockAddressRepo.EXPECT().
+			FindActiveAddressesByOwner(ctx, userID, entity.OwnerTypeMerchantProfile).
+			Return(nil, nil)
+	})
+
+	_, err := fx.service.UpdateMerchantDiscoveryProfile(ctx, userID, input)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, domainerrors.ErrValidationFailed)
+}
+
+func TestProfileService_UpdateMerchantDiscoveryProfile_PropagatesInvalidDiscoveryReferences(t *testing.T) {
+	fx := createTestProfileService(t)
+
+	ctx := context.Background()
+	userID := uuid.New()
+	categoryID := uuid.New()
+	user := &entity.User{
+		ID: userID,
+		MerchantProfile: &entity.MerchantProfile{
+			UserID: userID,
+		},
+	}
+	input := &usecase.UpdateMerchantDiscoveryProfileInput{
+		DiscoveryCategoryID: usecase.OptionalUUIDUpdate{IsSet: true, Value: &categoryID},
+	}
+
+	executeProfileDiscoveryTx(t, fx, ctx, func(factory *mockRepo.MockRepositoryFactory) {
+		mockUserRepo := mockRepo.NewMockUserRepository(t)
+		mockDiscoveryRepo := mockRepo.NewMockDiscoveryRepository(t)
+		mockAddressRepo := mockRepo.NewMockAddressRepository(t)
+		factory.EXPECT().UserRepo().Return(mockUserRepo)
+		factory.EXPECT().DiscoveryRepo().Return(mockDiscoveryRepo)
+		factory.EXPECT().AddressRepo().Return(mockAddressRepo)
+		mockUserRepo.EXPECT().FindByID(ctx, userID).Return(user, nil)
+		mockDiscoveryRepo.EXPECT().FindCategoryByID(ctx, categoryID).Return(nil, domainerrors.ErrDiscoveryCategoryNotFound)
+	})
+
+	_, err := fx.service.UpdateMerchantDiscoveryProfile(ctx, userID, input)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, domainerrors.ErrDiscoveryCategoryNotFound))
+}

--- a/internal/usecase/profile_usecase.go
+++ b/internal/usecase/profile_usecase.go
@@ -13,6 +13,8 @@ type ProfileUsecase interface {
 	GetProfile(ctx context.Context, userID uuid.UUID) (*entity.User, error)
 	UpdateUserProfile(ctx context.Context, userID uuid.UUID, input *UpdateUserProfileInput) error
 	UpdateMerchantProfile(ctx context.Context, userID uuid.UUID, input *UpdateMerchantProfileInput) error
+	GetMerchantDiscoveryProfile(ctx context.Context, userID uuid.UUID) (*MerchantDiscoveryProfileResult, error)
+	UpdateMerchantDiscoveryProfile(ctx context.Context, userID uuid.UUID, input *UpdateMerchantDiscoveryProfileInput) (*MerchantDiscoveryProfileResult, error)
 	SubmitMerchantVerification(ctx context.Context, userID uuid.UUID, input *SubmitMerchantVerificationInput) error
 	SwitchToMerchant(ctx context.Context, userID uuid.UUID, input *SwitchToMerchantInput) error
 	GetUserRole(ctx context.Context, userID uuid.UUID) ([]string, error)
@@ -29,6 +31,30 @@ type UpdateUserProfileInput struct {
 type UpdateMerchantProfileInput struct {
 	StoreName        *string `json:"store_name,omitempty"`
 	StoreDescription *string `json:"store_description,omitempty"`
+}
+
+type OptionalUUIDUpdate struct {
+	IsSet bool
+	Value *uuid.UUID
+}
+
+type UpdateMerchantDiscoveryProfileInput struct {
+	DiscoveryCategoryID    OptionalUUIDUpdate
+	DiscoverySubcategoryID OptionalUUIDUpdate
+	ActiveHubID            OptionalUUIDUpdate
+	IsPublic               *bool
+}
+
+type MerchantDiscoveryProfileResult struct {
+	DiscoveryCategoryID      *uuid.UUID                   `json:"discovery_category_id,omitempty"`
+	DiscoverySubcategoryID   *uuid.UUID                   `json:"discovery_subcategory_id,omitempty"`
+	ActiveHubID              *uuid.UUID                   `json:"active_hub_id,omitempty"`
+	IsPublic                 bool                         `json:"is_public"`
+	IsVerified               bool                         `json:"is_verified"`
+	HasActivePrimaryLocation bool                         `json:"has_active_primary_location"`
+	DiscoveryCategory        *entity.DiscoveryCategory    `json:"discovery_category,omitempty"`
+	DiscoverySubcategory     *entity.DiscoverySubcategory `json:"discovery_subcategory,omitempty"`
+	ActiveHub                *entity.Hub                  `json:"active_hub,omitempty"`
 }
 
 type SubmitMerchantVerificationInput struct {


### PR DESCRIPTION
## Summary
- Add merchant discovery profile read/update APIs.
- Validate discovery category, subcategory, hub, public visibility, merchant verification, and active primary location eligibility.
- Support clearing active hub with `active_hub_id: null`.
- Update Tier 2 Phase 2 checklist/status.
- Align local Postgres 18/PostGIS compose data directory with the new PGDATA layout.

## Validation
- gofmt
- git diff --check
- go test ./internal/usecase/impl/... ./internal/delivery/api/router/handler/...
- go test ./...
- docker compose config

## Notes
- Public discovery remains disabled unless the merchant is verified, has valid active discovery values, and has an active primary merchant location.
- Existing inactive discovery references do not block turning `is_public` off.
- Existing local Postgres volumes created with the previous mount path may need recreation or dump/restore.
