### PR TITLE
ci: add supabase migration workflow safeguards

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,4 @@
+## Checklist
+
+- [ ] If this PR adds or changes PostgreSQL functions, I checked whether a Supabase post-migration hardening change is required.
+- [ ] If this PR changes extension, PostGIS, or database `search_path` behavior, I checked the Supabase migration workflow and README guidance.

--- a/.github/workflows/deploy-cloud-run-job-dev.yml
+++ b/.github/workflows/deploy-cloud-run-job-dev.yml
@@ -18,6 +18,11 @@ on:
         required: false
         type: boolean
         default: false
+      run_supabase_migration:
+        description: "Run Supabase-only pre/post database migrations."
+        required: false
+        type: boolean
+        default: false
       configure_scheduler:
         description: "Create or update Cloud Scheduler trigger. Leave off for image-only job deploys."
         required: false
@@ -53,6 +58,7 @@ jobs:
       target: ${{ inputs.target }}
       image_ref: ${{ inputs.image_ref }}
       run_migration: ${{ inputs.run_migration }}
+      run_supabase_migration: ${{ inputs.run_supabase_migration }}
       configure_scheduler: ${{ inputs.configure_scheduler }}
       execute_now: ${{ inputs.execute_now }}
       schedule: ${{ inputs.schedule }}

--- a/.github/workflows/deploy-cloud-run-job-prod.yml
+++ b/.github/workflows/deploy-cloud-run-job-prod.yml
@@ -18,6 +18,11 @@ on:
         required: false
         type: boolean
         default: false
+      run_supabase_migration:
+        description: "Run Supabase-only pre/post database migrations."
+        required: false
+        type: boolean
+        default: false
       configure_scheduler:
         description: "Create or update Cloud Scheduler trigger. Leave off for image-only job deploys."
         required: false
@@ -53,6 +58,7 @@ jobs:
       target: ${{ inputs.target }}
       image_ref: ${{ inputs.image_ref }}
       run_migration: ${{ inputs.run_migration }}
+      run_supabase_migration: ${{ inputs.run_supabase_migration }}
       configure_scheduler: ${{ inputs.configure_scheduler }}
       execute_now: ${{ inputs.execute_now }}
       schedule: ${{ inputs.schedule }}

--- a/.github/workflows/deploy-cloud-run-reusable.yml
+++ b/.github/workflows/deploy-cloud-run-reusable.yml
@@ -25,6 +25,11 @@ on:
         required: false
         default: false
         type: boolean
+      run_supabase_migration:
+        description: "Run Supabase-only pre/post database migrations."
+        required: false
+        default: false
+        type: boolean
       enable_cloudflare_sync:
         description: "Sync Cloudflare transform rule after deploy"
         required: false
@@ -128,7 +133,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Go version
-        if: ${{ inputs.run_migration }}
+        if: ${{ inputs.run_migration || inputs.run_supabase_migration }}
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
@@ -146,14 +151,72 @@ jobs:
         with:
           project_id: ${{ env.PROJECT_ID }}
 
+      - name: Install goose
+        if: ${{ inputs.run_migration || inputs.run_supabase_migration }}
+        run: |
+          set -euo pipefail
+
+          go install github.com/pressly/goose/v3/cmd/goose@latest
+
+      - name: Resolve migration database secret
+        if: ${{ inputs.run_migration || inputs.run_supabase_migration }}
+        id: migration_db
+        run: |
+          set -euo pipefail
+
+          MIGRATION_SECRET="postgres-migration-dsn"
+          if ! gcloud secrets describe "${MIGRATION_SECRET}" --project="${PROJECT_ID}" >/dev/null 2>&1; then
+            MIGRATION_SECRET="postgres-master-dsn"
+            echo "::warning::Secret postgres-migration-dsn was not found; falling back to postgres-master-dsn for migrations."
+          fi
+
+          PG_URI=$(gcloud secrets versions access latest --secret="${MIGRATION_SECRET}" --project="${PROJECT_ID}")
+          if printf '%s' "${PG_URI}" | grep -Eq 'pooler\.supabase\.com' \
+            && printf '%s' "${PG_URI}" | grep -Eq '(:6543|port=6543)([^0-9]|$)'; then
+            echo "::error::Migration DSN secret ${MIGRATION_SECRET} points to the Supabase transaction pooler. Use a direct connection or Supavisor session-mode DSN for migrations."
+            exit 1
+          fi
+
+          echo "secret=${MIGRATION_SECRET}" >> "${GITHUB_OUTPUT}"
+          echo "Using ${MIGRATION_SECRET} for database migrations."
+
+      - name: Run Supabase pre-migrations
+        if: ${{ inputs.run_supabase_migration }}
+        run: |
+          set -euo pipefail
+
+          PG_URI=$(gcloud secrets versions access latest --secret="${{ steps.migration_db.outputs.secret }}" --project="${PROJECT_ID}")
+          PGOPTIONS="-c search_path=public,extensions" "$(go env GOPATH)/bin/goose" \
+            -table goose_supabase_pre_version \
+            -dir ./database/migration/supabase/pre \
+            postgres "${PG_URI}" up
+
       - name: Run Database Migration
         if: ${{ inputs.run_migration }}
         run: |
           set -euo pipefail
 
-          go install github.com/pressly/goose/v3/cmd/goose@latest
-          PG_URI=$(gcloud secrets versions access latest --secret="postgres-master-dsn" --project="${PROJECT_ID}")
-          "$(go env GOPATH)/bin/goose" postgres "${PG_URI}" -dir ./database/migration/postgres up
+          PG_URI=$(gcloud secrets versions access latest --secret="${{ steps.migration_db.outputs.secret }}" --project="${PROJECT_ID}")
+          if [ "${{ inputs.run_supabase_migration }}" = "true" ]; then
+            PGOPTIONS="-c search_path=public,extensions" "$(go env GOPATH)/bin/goose" \
+              -dir ./database/migration/postgres \
+              postgres "${PG_URI}" up
+          else
+            "$(go env GOPATH)/bin/goose" \
+              -dir ./database/migration/postgres \
+              postgres "${PG_URI}" up
+          fi
+
+      - name: Run Supabase post-migrations
+        if: ${{ inputs.run_supabase_migration }}
+        run: |
+          set -euo pipefail
+
+          PG_URI=$(gcloud secrets versions access latest --secret="${{ steps.migration_db.outputs.secret }}" --project="${PROJECT_ID}")
+          PGOPTIONS="-c search_path=public,extensions" "$(go env GOPATH)/bin/goose" \
+            -table goose_supabase_post_version \
+            -dir ./database/migration/supabase/post \
+            postgres "${PG_URI}" up
 
       - name: Resolve image reference
         id: image

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -19,6 +19,11 @@ on:
         required: false
         type: boolean
         default: false
+      run_supabase_migration:
+        description: "Run Supabase-only pre/post database migrations."
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   deploy:
@@ -29,5 +34,6 @@ jobs:
       target: ${{ inputs.target }}
       image_ref: ${{ inputs.image_ref }}
       run_migration: ${{ inputs.run_migration }}
+      run_supabase_migration: ${{ inputs.run_supabase_migration }}
       enable_cloudflare_sync: false
     secrets: inherit

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -19,6 +19,11 @@ on:
         required: false
         type: boolean
         default: false
+      run_supabase_migration:
+        description: "Run Supabase-only pre/post database migrations."
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   deploy:
@@ -29,5 +34,6 @@ jobs:
       target: ${{ inputs.target }}
       image_ref: ${{ inputs.image_ref }}
       run_migration: ${{ inputs.run_migration }}
+      run_supabase_migration: ${{ inputs.run_supabase_migration }}
       enable_cloudflare_sync: true
     secrets: inherit

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The pre-migrations configure the extension schema before shared migrations run. 
 CREATE SCHEMA IF NOT EXISTS extensions;
 CREATE EXTENSION IF NOT EXISTS citext SCHEMA extensions;
 CREATE EXTENSION IF NOT EXISTS postgis SCHEMA extensions;
-ALTER ROLE your_app_database_role SET search_path = public, extensions;
+ALTER ROLE your_app_database_role SET search_path TO "$user", public, extensions;
 ```
 
 The post-migrations apply Supabase function hardening with schema-qualified references and fixed function `search_path` values.

--- a/README.md
+++ b/README.md
@@ -57,25 +57,40 @@ Make sure you have PostgreSQL 18+ with PostGIS extension installed and running. 
 
 **Supabase Deployment - Required PostGIS Setup:**
 
-If you're deploying on Supabase, run the following SQL in the SQL Editor to properly configure PostGIS in the `extensions` schema:
+If you're deploying on Supabase, enable `run_supabase_migration` in the deploy workflow. Supabase-specific database changes are managed by goose with separate version tables, so each Supabase migration is applied once per database:
+
+- `database/migration/supabase/pre` runs before the shared PostgreSQL migrations using `goose_supabase_pre_version`.
+- `database/migration/supabase/post` runs after the shared PostgreSQL migrations using `goose_supabase_post_version`.
+
+Database migrations should use a dedicated GCP Secret Manager secret named `postgres-migration-dsn`. For Supabase, this DSN must be a direct connection or Supavisor session-mode connection on port `5432`; do not use the transaction pooler on port `6543` for migrations because session-level settings such as `PGOPTIONS` / `search_path` are not reliable there. Runtime Cloud Run services still use `postgres-master-dsn`, which may point at the transaction pooler because `POSTGRES_PRESET=supabase_transaction` disables prepared statement behavior in the app connection.
+
+The pre-migrations configure the extension schema before shared migrations run. They perform the equivalent of:
 
 ```sql
--- 1. Drop existing PostGIS extension (WARNING: This will also drop geometry columns in your tables!)
-DROP EXTENSION IF EXISTS postgis CASCADE;
-
--- 2. Create a clean extensions schema
 CREATE SCHEMA IF NOT EXISTS extensions;
-GRANT USAGE ON SCHEMA extensions TO postgres, anon, authenticated, service_role;
-
--- 3. Set search path (so applications can find it without code changes)
-ALTER DATABASE postgres SET search_path TO "$user", public, extensions;
-ALTER ROLE authenticated SET search_path TO "$user", public, extensions;
-ALTER ROLE anon SET search_path TO "$user", public, extensions;
-ALTER ROLE service_role SET search_path TO "$user", public, extensions;
-
--- 4. Reinstall PostGIS in the new schema
-CREATE EXTENSION postgis SCHEMA extensions;
+CREATE EXTENSION IF NOT EXISTS citext SCHEMA extensions;
+CREATE EXTENSION IF NOT EXISTS postgis SCHEMA extensions;
+ALTER ROLE your_app_database_role SET search_path = public, extensions;
 ```
+
+The post-migrations apply Supabase function hardening with schema-qualified references and fixed function `search_path` values.
+
+Recommended workflow usage:
+
+- New Supabase database: enable `run_supabase_migration` and `run_migration`.
+- Normal schema migration: enable only `run_migration`.
+- Migration that adds or changes database functions and needs Supabase hardening: enable `run_supabase_migration` and `run_migration`.
+- Supabase-only fix on an already migrated database: enable only `run_supabase_migration`.
+
+The standard Supabase API roles are handled by the pre-migration. If you add a non-standard API role that needs direct access to extension objects, keep it aligned with the same runtime search path:
+
+```sql
+GRANT USAGE ON SCHEMA extensions TO your_api_role;
+ALTER ROLE your_api_role SET search_path TO "$user", public, extensions;
+```
+
+Do not run `DROP EXTENSION postgis CASCADE` on a migrated database. It drops dependent PostGIS objects such as `geometry` columns and spatial indexes.
+The Supabase pre-migration does not relocate an extension that already exists in another schema; use it on a new Supabase database or manually remediate an already-drifted database.
 
 4. **Configure local config:**
 

--- a/database/migration/supabase/post/20260521000200_harden_baseline_functions.sql
+++ b/database/migration/supabase/post/20260521000200_harden_baseline_functions.sql
@@ -3,19 +3,40 @@
 
 -- +goose StatementBegin
 DO $$
+DECLARE
+    missing_object TEXT;
 BEGIN
-    IF to_regclass('public.users') IS NULL
-        OR to_regclass('public.user_authentications') IS NULL
-        OR to_regclass('public.merchant_profiles') IS NULL
-        OR to_regclass('public.addresses') IS NULL
-        OR to_regnamespace('extensions') IS NULL
-        OR to_regprocedure('public.update_updated_at_column()') IS NULL
-        OR to_regprocedure('public.uuid_generate_v7()') IS NULL
-        OR to_regprocedure('public.uuid_generate_v4()') IS NULL
-        OR to_regprocedure('public.update_location_from_lat_lng()') IS NULL
-        OR to_regprocedure('public.sync_user_soft_delete_dependents()') IS NULL
-    ) THEN
-        RAISE EXCEPTION 'shared PostgreSQL migrations and Supabase pre-migrations must be applied before Supabase function hardening';
+    SELECT object_name
+    INTO missing_object
+    FROM (
+        VALUES
+            ('schema extensions', to_regnamespace('extensions') IS NOT NULL),
+            ('table public.users', to_regclass('public.users') IS NOT NULL),
+            ('table public.user_profiles', to_regclass('public.user_profiles') IS NOT NULL),
+            ('table public.merchant_profiles', to_regclass('public.merchant_profiles') IS NOT NULL),
+            ('table public.user_authentications', to_regclass('public.user_authentications') IS NOT NULL),
+            ('table public.refresh_tokens', to_regclass('public.refresh_tokens') IS NOT NULL),
+            ('table public.addresses', to_regclass('public.addresses') IS NOT NULL),
+            ('table public.menu_items', to_regclass('public.menu_items') IS NOT NULL),
+            ('table public.login_attempts', to_regclass('public.login_attempts') IS NOT NULL),
+            ('table public.user_devices', to_regclass('public.user_devices') IS NOT NULL),
+            ('table public.user_merchant_subscriptions', to_regclass('public.user_merchant_subscriptions') IS NOT NULL),
+            ('table public.merchant_location_notifications', to_regclass('public.merchant_location_notifications') IS NOT NULL),
+            ('table public.notification_logs', to_regclass('public.notification_logs') IS NOT NULL),
+            ('table public.discovery_categories', to_regclass('public.discovery_categories') IS NOT NULL),
+            ('table public.discovery_subcategories', to_regclass('public.discovery_subcategories') IS NOT NULL),
+            ('table public.hubs', to_regclass('public.hubs') IS NOT NULL),
+            ('function public.update_updated_at_column()', to_regprocedure('public.update_updated_at_column()') IS NOT NULL),
+            ('function public.uuid_generate_v7()', to_regprocedure('public.uuid_generate_v7()') IS NOT NULL),
+            ('function public.uuid_generate_v4()', to_regprocedure('public.uuid_generate_v4()') IS NOT NULL),
+            ('function public.update_location_from_lat_lng()', to_regprocedure('public.update_location_from_lat_lng()') IS NOT NULL),
+            ('function public.sync_user_soft_delete_dependents()', to_regprocedure('public.sync_user_soft_delete_dependents()') IS NOT NULL)
+    ) AS required_objects(object_name, object_exists)
+    WHERE NOT object_exists
+    LIMIT 1;
+
+    IF missing_object IS NOT NULL THEN
+        RAISE EXCEPTION 'shared PostgreSQL migrations and Supabase pre-migrations must be applied before Supabase function hardening; missing %', missing_object;
     END IF;
 END;
 $$;

--- a/database/migration/supabase/post/20260521000200_harden_baseline_functions.sql
+++ b/database/migration/supabase/post/20260521000200_harden_baseline_functions.sql
@@ -1,0 +1,94 @@
+-- +goose Up
+-- SQL in this section is executed when the migration is applied.
+
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF to_regclass('public.users') IS NULL
+        OR to_regclass('public.user_authentications') IS NULL
+        OR to_regclass('public.merchant_profiles') IS NULL
+        OR to_regclass('public.addresses') IS NULL
+        OR to_regnamespace('extensions') IS NULL
+        OR to_regprocedure('public.update_updated_at_column()') IS NULL
+        OR to_regprocedure('public.uuid_generate_v7()') IS NULL
+        OR to_regprocedure('public.uuid_generate_v4()') IS NULL
+        OR to_regprocedure('public.update_location_from_lat_lng()') IS NULL
+        OR to_regprocedure('public.sync_user_soft_delete_dependents()') IS NULL
+    ) THEN
+        RAISE EXCEPTION 'shared PostgreSQL migrations and Supabase pre-migrations must be applied before Supabase function hardening';
+    END IF;
+END;
+$$;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION public.update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = pg_catalog.now();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION public.uuid_generate_v7()
+RETURNS UUID AS $$
+BEGIN
+    RETURN pg_catalog.uuidv7();
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION public.uuid_generate_v4()
+RETURNS UUID AS $$
+BEGIN
+    RETURN pg_catalog.gen_random_uuid();
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION public.update_location_from_lat_lng()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.location = extensions.ST_SetSRID(
+        extensions.ST_MakePoint(NEW.longitude, NEW.latitude),
+        4326
+    );
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION public.sync_user_soft_delete_dependents()
+RETURNS TRIGGER AS $$
+BEGIN
+    UPDATE public.user_authentications
+    SET deleted_at = NEW.deleted_at
+    WHERE user_id = NEW.id
+      AND deleted_at IS DISTINCT FROM NEW.deleted_at;
+
+    UPDATE public.merchant_profiles
+    SET deleted_at = NEW.deleted_at
+    WHERE user_id = NEW.id
+      AND deleted_at IS DISTINCT FROM NEW.deleted_at;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+ALTER FUNCTION public.update_updated_at_column() SET search_path = '';
+ALTER FUNCTION public.sync_user_soft_delete_dependents() SET search_path = '';
+ALTER FUNCTION public.uuid_generate_v4() SET search_path = '';
+ALTER FUNCTION public.uuid_generate_v7() SET search_path = '';
+ALTER FUNCTION public.update_location_from_lat_lng() SET search_path = '';
+
+-- +goose Down
+-- SQL in this section is executed when the migration is rolled back.
+
+-- Intentionally no-op. Function hardening is a forward-only Supabase security
+-- posture; rolling it back would reintroduce unsafe search_path behavior.

--- a/database/migration/supabase/pre/20260521000100_configure_extensions.sql
+++ b/database/migration/supabase/pre/20260521000100_configure_extensions.sql
@@ -9,7 +9,7 @@ CREATE EXTENSION IF NOT EXISTS postgis SCHEMA extensions;
 -- +goose StatementBegin
 DO $$
 BEGIN
-    EXECUTE format('ALTER ROLE %I SET search_path = public, extensions', CURRENT_USER);
+    EXECUTE format('ALTER ROLE %I SET search_path = "$user", public, extensions', CURRENT_USER);
 
     IF EXISTS (SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = 'postgres') THEN
         GRANT USAGE ON SCHEMA extensions TO postgres;

--- a/database/migration/supabase/pre/20260521000100_configure_extensions.sql
+++ b/database/migration/supabase/pre/20260521000100_configure_extensions.sql
@@ -1,0 +1,40 @@
+-- +goose Up
+-- SQL in this section is executed when the migration is applied.
+
+CREATE SCHEMA IF NOT EXISTS extensions;
+
+CREATE EXTENSION IF NOT EXISTS citext SCHEMA extensions;
+CREATE EXTENSION IF NOT EXISTS postgis SCHEMA extensions;
+
+-- +goose StatementBegin
+DO $$
+BEGIN
+    EXECUTE format('ALTER ROLE %I SET search_path = public, extensions', CURRENT_USER);
+
+    IF EXISTS (SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = 'postgres') THEN
+        GRANT USAGE ON SCHEMA extensions TO postgres;
+    END IF;
+
+    IF EXISTS (SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = 'anon') THEN
+        GRANT USAGE ON SCHEMA extensions TO anon;
+        ALTER ROLE anon SET search_path = "$user", public, extensions;
+    END IF;
+
+    IF EXISTS (SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = 'authenticated') THEN
+        GRANT USAGE ON SCHEMA extensions TO authenticated;
+        ALTER ROLE authenticated SET search_path = "$user", public, extensions;
+    END IF;
+
+    IF EXISTS (SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = 'service_role') THEN
+        GRANT USAGE ON SCHEMA extensions TO service_role;
+        ALTER ROLE service_role SET search_path = "$user", public, extensions;
+    END IF;
+END;
+$$;
+-- +goose StatementEnd
+
+-- +goose Down
+-- SQL in this section is executed when the migration is rolled back.
+
+-- Intentionally no-op. Extension placement and role search_path are environment
+-- bootstrap state and should not be destroyed by migration rollback.

--- a/docs/cloud-run-jobs.md
+++ b/docs/cloud-run-jobs.md
@@ -39,13 +39,18 @@ Inputs:
 | `target` | Cloud Run Job target. Currently only `device-cleanup`. |
 | `image_ref` | Required image tag or commit SHA to deploy. |
 | `run_migration` | Runs the shared database migrations before deploy when this release includes schema changes. Defaults to `false`. |
+| `run_supabase_migration` | Runs versioned Supabase-specific pre/post database migrations. Defaults to `false`. |
 | `configure_scheduler` | Creates or updates the Cloud Scheduler trigger configured by `schedule`, `schedule_time_zone`, and `scheduler_name`. Leave disabled for image-only job deploys. Defaults to `false`. |
 | `execute_now` | Executes the job immediately after deploy. Defaults to `false`. |
 | `schedule` | Cloud Scheduler cron expression. Defaults to `0 3 * * *`. |
 | `schedule_time_zone` | Cloud Scheduler time zone. Defaults to `Asia/Taipei`. |
 | `scheduler_name` | Cloud Scheduler job name. Defaults to `device-cleanup-daily` for this job; change it if `schedule` is no longer daily or if adding another job target. |
 
-The workflow reuses the shared Cloud Run deployment setup used by services: Google auth, Artifact Registry image resolution, optional migration, and image existence verification. If `run_migration` is enabled, it runs the same goose migration path used by service deploys before deploying the job. The deployment branch for jobs runs `gcloud run jobs deploy` instead of `gcloud run services replace`.
+The workflow reuses the shared Cloud Run deployment setup used by services: Google auth, Artifact Registry image resolution, optional versioned Supabase database migrations, optional shared migration, and image existence verification. If `run_migration` is enabled, it runs the same goose migration path used by service deploys before deploying the job. The deployment branch for jobs runs `gcloud run jobs deploy` instead of `gcloud run services replace`.
+
+Supabase workflow usage matches the README database setup guidance: enable both `run_supabase_migration` and `run_migration` for a new Supabase database, use only `run_migration` for normal shared schema changes, and enable both when a shared migration adds or changes functions that need Supabase hardening.
+
+When migrations run, the shared workflow prefers the GCP Secret Manager secret `postgres-migration-dsn` and falls back to `postgres-master-dsn` only when the migration secret does not exist. For Supabase, configure `postgres-migration-dsn` as a direct or session-mode connection on port `5432`; transaction pooler DSNs on port `6543` are rejected before goose runs.
 
 The job deploy sets the same database and logging runtime configuration documented below. Firebase and HTTP server settings are not required.
 


### PR DESCRIPTION
## Summary

- Area: Cloud Run deployment and Supabase migrations
- Add versioned Supabase pre/post goose migrations for extension setup and function hardening.
- Add deploy workflow support for Supabase-only migrations and a dedicated postgres-migration-dsn secret with transaction-pooler guardrails.
- Document the runtime versus migration DSN split and add a PR checklist for PostgreSQL function/search_path changes.

## Validation

- git diff --check
- ruby -ryaml -e 'ARGV.each { |path| YAML.load_file(path) }; puts "workflow yaml ok"' .github/workflows/deploy-cloud-run-reusable.yml .github/workflows/deploy-dev.yml .github/workflows/deploy-prod.yml .github/workflows/deploy-cloud-run-job-dev.yml .github/workflows/deploy-cloud-run-job-prod.yml
- goose -dir ./database/migration/postgres validate
- goose -dir ./database/migration/supabase/pre validate
- goose -dir ./database/migration/supabase/post validate

## Risks

- Requires creating postgres-migration-dsn in GCP Secret Manager for Supabase deployments that currently use the transaction pooler runtime DSN.
- Workflow path was validated statically, not by running a live Cloud Run deployment or Supabase migration.