### PR TITLE
fix: add supabase uuidv7 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ If you're deploying on Supabase, enable `run_supabase_migration` in the deploy w
 
 Database migrations should use a dedicated GCP Secret Manager secret named `postgres-migration-dsn`. For Supabase, this DSN must be a direct connection or Supavisor session-mode connection on port `5432`; do not use the transaction pooler on port `6543` for migrations because session-level settings such as `PGOPTIONS` / `search_path` are not reliable there. Runtime Cloud Run services still use `postgres-master-dsn`, which may point at the transaction pooler because `POSTGRES_PRESET=supabase_transaction` disables prepared statement behavior in the app connection.
 
-The pre-migrations configure the extension schema before shared migrations run. They perform the equivalent of:
+The pre-migrations configure Supabase compatibility before shared migrations run, including the extension schema and a `public.uuidv7()` fallback when Supabase does not provide PostgreSQL's native `pg_catalog.uuidv7()` yet. For the extension schema, they perform the equivalent of:
 
 ```sql
 CREATE SCHEMA IF NOT EXISTS extensions;

--- a/database/migration/postgres/20260502173514_baseline_schema.sql
+++ b/database/migration/postgres/20260502173514_baseline_schema.sql
@@ -25,15 +25,6 @@ $$ LANGUAGE plpgsql;
 -- +goose StatementEnd
 
 -- +goose StatementBegin
-CREATE OR REPLACE FUNCTION uuid_generate_v4()
-RETURNS UUID AS $$
-BEGIN
-    RETURN gen_random_uuid();
-END;
-$$ LANGUAGE plpgsql;
--- +goose StatementEnd
-
--- +goose StatementBegin
 CREATE OR REPLACE FUNCTION update_location_from_lat_lng()
 RETURNS TRIGGER AS $$
 BEGIN
@@ -461,6 +452,5 @@ DROP TABLE IF EXISTS users;
 
 DROP FUNCTION IF EXISTS sync_user_soft_delete_dependents();
 DROP FUNCTION IF EXISTS update_location_from_lat_lng();
-DROP FUNCTION IF EXISTS uuid_generate_v4();
 DROP FUNCTION IF EXISTS uuid_generate_v7();
 DROP FUNCTION IF EXISTS update_updated_at_column();

--- a/database/migration/supabase/post/20260521000200_harden_baseline_functions.sql
+++ b/database/migration/supabase/post/20260521000200_harden_baseline_functions.sql
@@ -26,11 +26,11 @@ BEGIN
             ('table public.discovery_categories', to_regclass('public.discovery_categories') IS NOT NULL),
             ('table public.discovery_subcategories', to_regclass('public.discovery_subcategories') IS NOT NULL),
             ('table public.hubs', to_regclass('public.hubs') IS NOT NULL),
-            ('function public.update_updated_at_column()', to_regprocedure('public.update_updated_at_column()') IS NOT NULL),
-            ('function public.uuid_generate_v7()', to_regprocedure('public.uuid_generate_v7()') IS NOT NULL),
-            ('function public.uuidv7() compatibility', to_regprocedure('pg_catalog.uuidv7()') IS NOT NULL OR to_regprocedure('public.uuidv7()') IS NOT NULL),
-            ('function public.update_location_from_lat_lng()', to_regprocedure('public.update_location_from_lat_lng()') IS NOT NULL),
-            ('function public.sync_user_soft_delete_dependents()', to_regprocedure('public.sync_user_soft_delete_dependents()') IS NOT NULL)
+            ('function public.update_updated_at_column()', pg_catalog.to_regprocedure('public.update_updated_at_column()') IS NOT NULL),
+            ('function public.uuid_generate_v7()', pg_catalog.to_regprocedure('public.uuid_generate_v7()') IS NOT NULL),
+            ('function public.uuidv7() compatibility', pg_catalog.to_regprocedure('pg_catalog.uuidv7()') IS NOT NULL OR pg_catalog.to_regprocedure('public.uuidv7()') IS NOT NULL),
+            ('function public.update_location_from_lat_lng()', pg_catalog.to_regprocedure('public.update_location_from_lat_lng()') IS NOT NULL),
+            ('function public.sync_user_soft_delete_dependents()', pg_catalog.to_regprocedure('public.sync_user_soft_delete_dependents()') IS NOT NULL)
     ) AS required_objects(object_name, object_exists)
     WHERE NOT object_exists
     LIMIT 1;
@@ -55,7 +55,7 @@ $$ LANGUAGE plpgsql;
 -- +goose StatementBegin
 DO $$
 BEGIN
-    IF to_regprocedure('pg_catalog.uuidv7()') IS NULL THEN
+    IF pg_catalog.to_regprocedure('pg_catalog.uuidv7()') IS NULL THEN
         EXECUTE $create$
             CREATE OR REPLACE FUNCTION public.uuid_generate_v7()
             RETURNS UUID AS $function$

--- a/database/migration/supabase/post/20260521000200_harden_baseline_functions.sql
+++ b/database/migration/supabase/post/20260521000200_harden_baseline_functions.sql
@@ -53,16 +53,29 @@ $$ LANGUAGE plpgsql;
 -- +goose StatementEnd
 
 -- +goose StatementBegin
-CREATE OR REPLACE FUNCTION public.uuid_generate_v7()
-RETURNS UUID AS $$
+DO $$
 BEGIN
-    IF to_regprocedure('pg_catalog.uuidv7()') IS NOT NULL THEN
-        RETURN pg_catalog.uuidv7();
+    IF to_regprocedure('pg_catalog.uuidv7()') IS NULL THEN
+        EXECUTE $create$
+            CREATE OR REPLACE FUNCTION public.uuid_generate_v7()
+            RETURNS UUID AS $function$
+            BEGIN
+                RETURN public.uuidv7();
+            END;
+            $function$ LANGUAGE plpgsql
+        $create$;
+    ELSE
+        EXECUTE $create$
+            CREATE OR REPLACE FUNCTION public.uuid_generate_v7()
+            RETURNS UUID AS $function$
+            BEGIN
+                RETURN pg_catalog.uuidv7();
+            END;
+            $function$ LANGUAGE plpgsql
+        $create$;
     END IF;
-
-    RETURN public.uuidv7();
 END;
-$$ LANGUAGE plpgsql;
+$$;
 -- +goose StatementEnd
 
 -- +goose StatementBegin

--- a/database/migration/supabase/post/20260521000200_harden_baseline_functions.sql
+++ b/database/migration/supabase/post/20260521000200_harden_baseline_functions.sql
@@ -28,7 +28,7 @@ BEGIN
             ('table public.hubs', to_regclass('public.hubs') IS NOT NULL),
             ('function public.update_updated_at_column()', to_regprocedure('public.update_updated_at_column()') IS NOT NULL),
             ('function public.uuid_generate_v7()', to_regprocedure('public.uuid_generate_v7()') IS NOT NULL),
-            ('function public.uuid_generate_v4()', to_regprocedure('public.uuid_generate_v4()') IS NOT NULL),
+            ('function public.uuidv7() compatibility', to_regprocedure('pg_catalog.uuidv7()') IS NOT NULL OR to_regprocedure('public.uuidv7()') IS NOT NULL),
             ('function public.update_location_from_lat_lng()', to_regprocedure('public.update_location_from_lat_lng()') IS NOT NULL),
             ('function public.sync_user_soft_delete_dependents()', to_regprocedure('public.sync_user_soft_delete_dependents()') IS NOT NULL)
     ) AS required_objects(object_name, object_exists)
@@ -56,16 +56,11 @@ $$ LANGUAGE plpgsql;
 CREATE OR REPLACE FUNCTION public.uuid_generate_v7()
 RETURNS UUID AS $$
 BEGIN
-    RETURN pg_catalog.uuidv7();
-END;
-$$ LANGUAGE plpgsql;
--- +goose StatementEnd
+    IF to_regprocedure('pg_catalog.uuidv7()') IS NOT NULL THEN
+        RETURN pg_catalog.uuidv7();
+    END IF;
 
--- +goose StatementBegin
-CREATE OR REPLACE FUNCTION public.uuid_generate_v4()
-RETURNS UUID AS $$
-BEGIN
-    RETURN pg_catalog.gen_random_uuid();
+    RETURN public.uuidv7();
 END;
 $$ LANGUAGE plpgsql;
 -- +goose StatementEnd
@@ -104,7 +99,6 @@ $$ LANGUAGE plpgsql;
 
 ALTER FUNCTION public.update_updated_at_column() SET search_path = '';
 ALTER FUNCTION public.sync_user_soft_delete_dependents() SET search_path = '';
-ALTER FUNCTION public.uuid_generate_v4() SET search_path = '';
 ALTER FUNCTION public.uuid_generate_v7() SET search_path = '';
 ALTER FUNCTION public.update_location_from_lat_lng() SET search_path = '';
 

--- a/database/migration/supabase/pre/20260521000100_configure_extensions.sql
+++ b/database/migration/supabase/pre/20260521000100_configure_extensions.sql
@@ -9,6 +9,48 @@ CREATE EXTENSION IF NOT EXISTS postgis SCHEMA extensions;
 -- +goose StatementBegin
 DO $$
 BEGIN
+    IF to_regprocedure('pg_catalog.uuidv7()') IS NULL THEN
+        EXECUTE $compat$
+            CREATE OR REPLACE FUNCTION public.uuidv7()
+            RETURNS UUID
+            LANGUAGE sql
+            VOLATILE
+            SET search_path = ''
+            AS $function$
+            WITH uuid_parts AS (
+                SELECT
+                    pg_catalog.lpad(
+                        pg_catalog.to_hex(
+                            pg_catalog.floor(EXTRACT(EPOCH FROM pg_catalog.clock_timestamp()) * 1000)::bigint
+                        ),
+                        12,
+                        '0'
+                    ) AS unix_ts_ms,
+                    pg_catalog.replace(pg_catalog.gen_random_uuid()::text, '-', '') AS random_hex
+            )
+            SELECT (
+                pg_catalog.substr(unix_ts_ms, 1, 8) || '-' ||
+                pg_catalog.substr(unix_ts_ms, 9, 4) || '-' ||
+                '7' || pg_catalog.substr(random_hex, 1, 3) || '-' ||
+                pg_catalog.substr(
+                    '89ab',
+                    (pg_catalog.get_byte(pg_catalog.decode(pg_catalog.substr(random_hex, 4, 2), 'hex'), 0) % 4) + 1,
+                    1
+                ) ||
+                pg_catalog.substr(random_hex, 6, 3) || '-' ||
+                pg_catalog.substr(random_hex, 9, 12)
+            )::uuid
+            FROM uuid_parts;
+            $function$
+        $compat$;
+    END IF;
+END;
+$$;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DO $$
+BEGIN
     EXECUTE format('ALTER ROLE %I SET search_path = "$user", public, extensions', CURRENT_USER);
 
     IF EXISTS (SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = 'postgres') THEN

--- a/database/migration/supabase/pre/20260521000100_configure_extensions.sql
+++ b/database/migration/supabase/pre/20260521000100_configure_extensions.sql
@@ -9,7 +9,7 @@ CREATE EXTENSION IF NOT EXISTS postgis SCHEMA extensions;
 -- +goose StatementBegin
 DO $$
 BEGIN
-    IF to_regprocedure('pg_catalog.uuidv7()') IS NULL THEN
+    IF pg_catalog.to_regprocedure('pg_catalog.uuidv7()') IS NULL THEN
         EXECUTE $compat$
             CREATE OR REPLACE FUNCTION public.uuidv7()
             RETURNS UUID


### PR DESCRIPTION
## Summary
- keep shared PostgreSQL baseline on native PostgreSQL 18 uuidv7()
- add a Supabase-only public.uuidv7() fallback before shared migrations run
- harden Supabase uuid_generate_v7() to prefer native uuidv7() and fall back when needed
- remove unused uuid_generate_v4() migration function

## Validation
- goose -dir database/migration/postgres validate
- goose -dir database/migration/supabase/pre validate
- goose -dir database/migration/supabase/post validate
- git diff --cached --check

## Notes
- Local SQL execution was not run because psql is unavailable and the local Docker daemon is not running.
- For the failed dev Supabase database, recreate it for the cleanest validation because the old Supabase pre migration was already recorded before the fallback existed.