### PR TITLE
fix: allow merchant discovery setup

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,78 @@
+language: "en-US"
+tone_instructions: "Be concise and pragmatic. Prioritize correctness, security, maintainability, and test gaps over style nits."
+
+reviews:
+  profile: "chill"
+  request_changes_workflow: false
+  high_level_summary: true
+  review_status: true
+  review_details: false
+  commit_status: true
+  fail_commit_status: false
+  collapse_walkthrough: true
+  changed_files_summary: true
+  sequence_diagrams: false
+  estimate_code_review_effort: true
+  assess_linked_issues: true
+  related_issues: false
+  related_prs: false
+  suggested_labels: false
+  suggested_reviewers: false
+  in_progress_fortune: false
+  poem: false
+  enable_prompt_for_ai_agents: false
+  path_filters:
+    - "!**/.git/**"
+    - "!**/node_modules/**"
+    - "!**/dist/**"
+    - "!**/build/**"
+    - "!**/coverage/**"
+    - "!go.sum"
+    - "!internal/infra/persistence/postgres/query/**"
+    - "!internal/mocks/**"
+    - "!k6/**"
+  path_instructions:
+    - path: "**/*.go"
+      instructions: |
+        Focus on correctness, explicit error handling, context propagation, SQL safety, concurrency risks, and preserving existing package boundaries. Avoid cosmetic comments unless they hide a real bug.
+    - path: "internal/delivery/api/**"
+      instructions: |
+        Check API contract behavior: authn/authz boundaries, stable status codes, response envelope shape, request_id propagation, validation errors, and safe error details.
+    - path: "database/migration/**"
+      instructions: |
+        Check migration safety, reversible intent, Supabase compatibility, PostGIS extension schema usage, function search_path hardening, and rollback risk.
+    - path: "deploy/**"
+      instructions: |
+        Check Cloud Run runtime configuration, secret injection, service account usage, ingress/IAM exposure, and environment variable names.
+    - path: ".github/workflows/**"
+      instructions: |
+        Check workflow permissions, secret handling, path filters, deployment gates, and whether runtime config changes are reflected in Cloud Run service and job definitions.
+  auto_review:
+    enabled: true
+    drafts: false
+    auto_incremental_review: true
+    auto_pause_after_reviewed_commits: 5
+    ignore_title_keywords:
+      - "WIP"
+      - "DO NOT REVIEW"
+  finishing_touches:
+    docstrings:
+      enabled: false
+    unit_tests:
+      enabled: false
+    simplify:
+      enabled: false
+  tools:
+    golangci-lint:
+      enabled: true
+      config_file: ".golangci.yaml"
+    markdownlint:
+      enabled: true
+    yamllint:
+      enabled: true
+    actionlint:
+      enabled: true
+    zizmor:
+      enabled: true
+    github-checks:
+      enabled: true

--- a/config/config_demo.yaml
+++ b/config/config_demo.yaml
@@ -20,7 +20,7 @@ http:
 postgres:
   database: "auth_db"
   schema: "public"
-  searchPath: "public"
+  searchPath: "public,extensions"
   sslMode: "disable"
   master:
     host: "localhost"

--- a/internal/delivery/api/router/router.go
+++ b/internal/delivery/api/router/router.go
@@ -110,6 +110,11 @@ func (r *router) registerAPIV1Routes(e *echo.Echo) {
 }
 
 func (r *router) registerAPIV1UserRoutes(apiV1 *echo.Group) {
+	userGroup := apiV1.Group("/user")
+	{
+		userGroup.GET("/profile", r.userHandler.GetProfile)
+	}
+
 	locationsGroup := apiV1.Group("/locations")
 	{
 		locationsGroup.POST("/user", r.locationHandler.CreateUserLocation)
@@ -137,6 +142,13 @@ func (r *router) registerAPIV1UserRoutes(apiV1 *echo.Group) {
 }
 
 func (r *router) registerAPIV1SharedRoutes(apiV1 *echo.Group) {
+	discoveryGroup := apiV1.Group("/discovery")
+	{
+		discoveryGroup.GET("/categories", r.discoveryHandler.ListActiveCategories)
+		discoveryGroup.GET("/subcategories", r.discoveryHandler.ListActiveSubcategories)
+		discoveryGroup.GET("/hubs", r.discoveryHandler.ListActiveHubs)
+	}
+
 	locationsGroup := apiV1.Group("/locations/merchant")
 	locationsGroup.Use(r.authMiddleware.RequireRole(entity.RoleMerchant))
 	{
@@ -155,14 +167,6 @@ func (r *router) registerAPIV1ConsumerRoutes(apiV1 *echo.Group) {
 	{
 		consumerMerchantsGroup.GET("", r.discoveryHandler.SearchPublicMerchants)
 		consumerMerchantsGroup.GET("/:merchantId/menu", r.menuHandler.GetPublicMerchantMenu)
-	}
-
-	discoveryGroup := apiV1.Group("/discovery")
-	discoveryGroup.Use(r.authMiddleware.RequireRole(entity.RoleUser))
-	{
-		discoveryGroup.GET("/categories", r.discoveryHandler.ListActiveCategories)
-		discoveryGroup.GET("/subcategories", r.discoveryHandler.ListActiveSubcategories)
-		discoveryGroup.GET("/hubs", r.discoveryHandler.ListActiveHubs)
 	}
 }
 

--- a/internal/delivery/api/router/router_test.go
+++ b/internal/delivery/api/router/router_test.go
@@ -223,7 +223,7 @@ func newRouterTestEcho() *echo.Echo {
 }
 
 func newRouterTestRequest(method, target, token string) *http.Request {
-	req := httptest.NewRequest(method, target, nil)
+	req := httptest.NewRequestWithContext(context.Background(), method, target, nil)
 	req.Header.Set(echo.HeaderAuthorization, "Bearer "+token)
 
 	return req

--- a/internal/delivery/api/router/router_test.go
+++ b/internal/delivery/api/router/router_test.go
@@ -159,6 +159,26 @@ func TestRouter_DiscoveryValuesAllowMerchantRole(t *testing.T) {
 	}
 }
 
+func TestRouter_DiscoveryValuesRequireAuthentication(t *testing.T) {
+	e := newRouterTestEcho()
+
+	for _, path := range []string{
+		"/api/v1/discovery/categories",
+		"/api/v1/discovery/subcategories",
+		"/api/v1/discovery/hubs",
+	} {
+		t.Run(path, func(t *testing.T) {
+			req := newRouterTestRequest(http.MethodGet, path, "")
+			rec := httptest.NewRecorder()
+
+			e.ServeHTTP(rec, req)
+
+			require.Equal(t, http.StatusUnauthorized, rec.Code)
+			assert.Contains(t, rec.Body.String(), `"code":"UNAUTHORIZED"`)
+		})
+	}
+}
+
 func TestRouter_PublicMerchantSearchStillRequiresUserRole(t *testing.T) {
 	e := newRouterTestEcho()
 	req := newRouterTestRequest(http.MethodGet, "/api/v1/merchants", testMerchantToken)
@@ -224,7 +244,9 @@ func newRouterTestEcho() *echo.Echo {
 
 func newRouterTestRequest(method, target, token string) *http.Request {
 	req := httptest.NewRequestWithContext(context.Background(), method, target, nil)
-	req.Header.Set(echo.HeaderAuthorization, "Bearer "+token)
+	if token != "" {
+		req.Header.Set(echo.HeaderAuthorization, "Bearer "+token)
+	}
 
 	return req
 }

--- a/internal/delivery/api/router/router_test.go
+++ b/internal/delivery/api/router/router_test.go
@@ -1,0 +1,230 @@
+package router
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"radar/config"
+	apimiddleware "radar/internal/delivery/api/middleware"
+	"radar/internal/delivery/api/router/handler"
+	"radar/internal/domain/entity"
+	"radar/internal/domain/service"
+	"radar/internal/usecase"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testUserToken     = "user-token"
+	testMerchantToken = "merchant-token"
+)
+
+type routerTestTokenService struct {
+	claims map[string]*service.Claims
+}
+
+func (s *routerTestTokenService) GenerateTokens(uuid.UUID, []string) (string, string, error) {
+	return "", "", nil
+}
+
+func (s *routerTestTokenService) ValidateToken(token string) (*service.Claims, error) {
+	claims, ok := s.claims[token]
+	if !ok {
+		return nil, errors.New("invalid token")
+	}
+
+	return claims, nil
+}
+
+func (s *routerTestTokenService) GenerateOnboardingToken(uuid.UUID) (string, error) {
+	return "", nil
+}
+
+func (s *routerTestTokenService) GenerateLinkingToken(uuid.UUID, string, string, string, string) (string, error) {
+	return "", nil
+}
+
+func (s *routerTestTokenService) GetRefreshTokenDuration() time.Duration {
+	return time.Hour
+}
+
+func (s *routerTestTokenService) HashToken(token string) string {
+	return token
+}
+
+func (s *routerTestTokenService) RotateTokens(uuid.UUID, []string) (string, string, string, error) {
+	return "", "", "", nil
+}
+
+type routerTestDiscoveryUsecase struct{}
+
+func (uc *routerTestDiscoveryUsecase) ListActiveCategories(context.Context) (*usecase.ListDiscoveryCategoriesResult, error) {
+	return &usecase.ListDiscoveryCategoriesResult{
+		Categories: []*usecase.DiscoveryCategoryResult{{ID: uuid.New(), Slug: "food", Name: "Food"}},
+	}, nil
+}
+
+func (uc *routerTestDiscoveryUsecase) ListActiveSubcategories(context.Context) (*usecase.ListDiscoverySubcategoriesResult, error) {
+	return &usecase.ListDiscoverySubcategoriesResult{
+		Subcategories: []*usecase.DiscoverySubcategoryResult{{ID: uuid.New(), Slug: "meal"}},
+	}, nil
+}
+
+func (uc *routerTestDiscoveryUsecase) ListActiveHubs(context.Context) (*usecase.ListDiscoveryHubsResult, error) {
+	return &usecase.ListDiscoveryHubsResult{
+		Hubs: []*usecase.DiscoveryHubResult{{ID: uuid.New(), Slug: "night-market"}},
+	}, nil
+}
+
+func (uc *routerTestDiscoveryUsecase) SearchPublicMerchants(
+	_ context.Context,
+	input *usecase.SearchPublicMerchantsInput,
+) (*usecase.SearchPublicMerchantsResult, error) {
+	return &usecase.SearchPublicMerchantsResult{
+		Merchants: []*entity.PublicMerchantSearchItem{},
+		Pagination: &usecase.MerchantSearchPagination{
+			Page:     input.Page,
+			PageSize: input.PageSize,
+			Total:    0,
+		},
+	}, nil
+}
+
+type routerTestProfileUsecase struct{}
+
+func (uc *routerTestProfileUsecase) GetProfile(_ context.Context, userID uuid.UUID) (*entity.User, error) {
+	return &entity.User{ID: userID, Email: "tester@example.com"}, nil
+}
+
+func (uc *routerTestProfileUsecase) UpdateUserProfile(context.Context, uuid.UUID, *usecase.UpdateUserProfileInput) error {
+	return nil
+}
+
+func (uc *routerTestProfileUsecase) UpdateMerchantProfile(context.Context, uuid.UUID, *usecase.UpdateMerchantProfileInput) error {
+	return nil
+}
+
+func (uc *routerTestProfileUsecase) GetMerchantDiscoveryProfile(context.Context, uuid.UUID) (*usecase.MerchantDiscoveryProfileResult, error) {
+	return &usecase.MerchantDiscoveryProfileResult{}, nil
+}
+
+func (uc *routerTestProfileUsecase) UpdateMerchantDiscoveryProfile(
+	context.Context,
+	uuid.UUID,
+	*usecase.UpdateMerchantDiscoveryProfileInput,
+) (*usecase.MerchantDiscoveryProfileResult, error) {
+	return &usecase.MerchantDiscoveryProfileResult{}, nil
+}
+
+func (uc *routerTestProfileUsecase) SubmitMerchantVerification(context.Context, uuid.UUID, *usecase.SubmitMerchantVerificationInput) error {
+	return nil
+}
+
+func (uc *routerTestProfileUsecase) SwitchToMerchant(context.Context, uuid.UUID, *usecase.SwitchToMerchantInput) error {
+	return nil
+}
+
+func (uc *routerTestProfileUsecase) GetUserRole(context.Context, uuid.UUID) ([]string, error) {
+	return nil, nil
+}
+
+func TestRouter_DiscoveryValuesAllowMerchantRole(t *testing.T) {
+	e := newRouterTestEcho()
+
+	for _, tt := range []struct {
+		path string
+		key  string
+	}{
+		{path: "/api/v1/discovery/categories", key: `"categories"`},
+		{path: "/api/v1/discovery/subcategories", key: `"subcategories"`},
+		{path: "/api/v1/discovery/hubs", key: `"hubs"`},
+	} {
+		t.Run(tt.path, func(t *testing.T) {
+			req := newRouterTestRequest(http.MethodGet, tt.path, testMerchantToken)
+			rec := httptest.NewRecorder()
+
+			e.ServeHTTP(rec, req)
+
+			require.Equal(t, http.StatusOK, rec.Code)
+			assert.Contains(t, rec.Body.String(), tt.key)
+		})
+	}
+}
+
+func TestRouter_PublicMerchantSearchStillRequiresUserRole(t *testing.T) {
+	e := newRouterTestEcho()
+	req := newRouterTestRequest(http.MethodGet, "/api/v1/merchants", testMerchantToken)
+	rec := httptest.NewRecorder()
+
+	e.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Contains(t, rec.Body.String(), `"code":"FORBIDDEN"`)
+}
+
+func TestRouter_ProfileSupportsAPIV1AndLegacyRoutes(t *testing.T) {
+	e := newRouterTestEcho()
+
+	for _, path := range []string{"/api/v1/user/profile", "/user/profile"} {
+		t.Run(path, func(t *testing.T) {
+			req := newRouterTestRequest(http.MethodGet, path, testUserToken)
+			rec := httptest.NewRecorder()
+
+			e.ServeHTTP(rec, req)
+
+			require.Equal(t, http.StatusOK, rec.Code)
+			assert.Contains(t, rec.Body.String(), `"email":"tester@example.com"`)
+		})
+	}
+}
+
+func newRouterTestEcho() *echo.Echo {
+	userID := uuid.New()
+	tokenSvc := &routerTestTokenService{
+		claims: map[string]*service.Claims{
+			testUserToken: {
+				UserID: userID,
+				Roles:  []string{string(entity.RoleUser)},
+				Type:   service.TokenTypeAccess,
+			},
+			testMerchantToken: {
+				UserID: uuid.New(),
+				Roles:  []string{string(entity.RoleMerchant)},
+				Type:   service.TokenTypeAccess,
+			},
+		},
+	}
+
+	e := echo.New()
+	authMiddleware := apimiddleware.NewAuthMiddleware(tokenSvc, &config.Config{})
+	r := NewRouter(RouterParams{
+		UserHandler: handler.NewUserHandler(handler.UserHandlerParams{
+			ProfileUC: &routerTestProfileUsecase{},
+			Logger:    slog.Default(),
+		}),
+		DiscoveryHandler: handler.NewDiscoveryHandler(handler.DiscoveryHandlerParams{
+			DiscoveryUC: &routerTestDiscoveryUsecase{},
+			Logger:      slog.Default(),
+		}),
+		AuthMiddleware: authMiddleware,
+		Config:         &config.Config{},
+	})
+	r.RegisterRoutes(e)
+
+	return e
+}
+
+func newRouterTestRequest(method, target, token string) *http.Request {
+	req := httptest.NewRequest(method, target, nil)
+	req.Header.Set(echo.HeaderAuthorization, "Bearer "+token)
+
+	return req
+}

--- a/k6/full.js
+++ b/k6/full.js
@@ -409,7 +409,7 @@ export default function (setupData) {
     );
 
     const userProfileRes = get(
-      "/user/profile",
+      "/api/v1/user/profile",
       "full_get_profile",
       userLogin.token,
     );
@@ -427,7 +427,7 @@ export default function (setupData) {
     assertStatus(authTestRes, 200, "authenticated test route");
 
     const merchantProfileRes = get(
-      "/user/profile",
+      "/api/v1/user/profile",
       "full_get_merchant_profile",
       merchantLogin.token,
     );


### PR DESCRIPTION
## Summary

- Allow authenticated merchant accounts to list discovery categories, subcategories, and hubs for merchant discovery setup.
- Add `/api/v1/user/profile` while keeping legacy `/user/profile` compatible.
- Set demo/runtime config search path to `public,extensions` for Supabase PostGIS lookups.
- Add CodeRabbit review configuration for concise, low-noise PR reviews.

## Validation

- `go test ./internal/delivery/api/router`

## Checklist

- [ ] If this PR adds or changes PostgreSQL functions, I checked whether a Supabase post-migration hardening change is required.
- [x] If this PR changes extension, PostGIS, or database `search_path` behavior, I checked the Supabase migration workflow and README guidance.

## Notes

- Consumer public merchant search remains user-role only.
- Runtime deployments should rebuild/redeploy so `/app/config/config.yaml` includes `postgres.searchPath: public,extensions`.
- CodeRabbit requires the GitHub App to be installed on the repository.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added/organized API v1 endpoints for user profile access, supporting both the current and legacy routes.
  * Added shared discovery endpoints for categories, subcategories, and hubs.
* **Bug Fixes**
  * Updated discovery permissions so authenticated users get the intended access (including merchant access for discovery), while merchant search still enforces user-role restrictions.
* **Improvements**
  * Broadened PostgreSQL schema resolution to include `extensions`.
* **Tests**
  * Added router integration tests covering discovery access, authorization behavior, and profile route compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->