### PR TITLE
chore: update dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,13 +1,46 @@
-# Git
+# VCS
 .git
 .gitignore
 
-# Documentation
-README.md
-DOCKER_README.md
-LICENSE
+# Docker metadata
+Dockerfile*
+docker-compose*
+.dockerignore
 
-# Go
+# Documentation
+*.md
+LICENSE
+docs/
+
+# CI, deployment, and local verification
+.github/
+deploy/
+database/
+k6/
+
+# Development tooling
+.coderabbit.yaml
+.golangci.yaml
+.markdownlint.json
+.mockery.yaml
+
+# Local config and data
+.env
+.env.*
+config.yaml
+data/routing/
+data/pmtiles/
+*.osm.pbf
+*.geojson
+*.pmtiles
+
+# Go workspace, tests, tools, and binaries
+go.work
+go.work.sum
+*_test.go
+internal/mocks/
+cmd/gen/
+cmd/routing/
 *.exe
 *.exe~
 *.dll
@@ -15,12 +48,20 @@ LICENSE
 *.dylib
 *.test
 *.out
-go.work
-*_test.go
+
+# Build and coverage output
+bin/
+dist/
+build/
+coverage/
+*.cover
 
 # IDE
+.kiro/
 .vscode/
 .idea/
+.zed/
+.cursor/
 *.swp
 *.swo
 *~
@@ -41,26 +82,6 @@ logs/
 # Temporary files
 tmp/
 temp/
-
-# Docker
-Dockerfile*
-docker-compose*
-.dockerignore
-
-# Environment
-.env
-.env.local
-.env.*.local
-
-# Build artifacts
-bin/
-dist/
-build/
-
-# Test coverage
-coverage/
-*.cover
-*.out
 
 # Dependencies
 vendor/


### PR DESCRIPTION
## Summary

- Area: Docker build context
- Refresh `.dockerignore` for the current repo layout.
- Exclude CI, deployment, docs, local verification, test, tool, local config, routing data, and generated output files from Docker build context.
- Keep production build inputs available for the current Dockerfile targets.

## Validation

- Static check: reviewed `.dockerignore` diff.
- Static check: compared ignore rules against Dockerfile `COPY` inputs.
- Not run: Docker build or tests, per repo instruction to avoid running programs unless requested.

## Risks

- Low: `.dockerignore` only affects Docker build context, not compose runtime bind mounts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded and reorganized container ignore rules to exclude a wider range of local, build, test, editor, and documentation files.
  * Improved cleanup of temporary artifacts, logs, workspace files, and dependency directories from container contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->