### PR TITLE
fix: use discovery subcategories for menu categories

### DIFF
--- a/database/migration/postgres/20260626164834_menu_item_category_id.sql
+++ b/database/migration/postgres/20260626164834_menu_item_category_id.sql
@@ -21,5 +21,10 @@ DROP INDEX IF EXISTS idx_menu_items_category_id;
 ALTER TABLE menu_items
     DROP COLUMN IF EXISTS category_id;
 
+-- Original menu category values cannot be recovered after category is dropped.
+-- Use a valid legacy value only to restore the old NOT NULL schema shape.
 ALTER TABLE menu_items
-    ADD COLUMN category TEXT;
+    ADD COLUMN category TEXT NOT NULL DEFAULT 'main';
+
+ALTER TABLE menu_items
+    ALTER COLUMN category DROP DEFAULT;

--- a/database/migration/postgres/20260626164834_menu_item_category_id.sql
+++ b/database/migration/postgres/20260626164834_menu_item_category_id.sql
@@ -1,0 +1,25 @@
+-- +goose Up
+-- SQL in this section is executed when the migration is applied.
+
+ALTER TABLE menu_items
+    ADD COLUMN category_id UUID;
+
+CREATE INDEX idx_menu_items_category_id
+    ON menu_items(category_id);
+
+COMMENT ON COLUMN menu_items.category_id IS
+'Discovery subcategory selected by the merchant for this menu item. Intentionally not constrained by foreign key so merchants can repair stale taxonomy references.';
+
+ALTER TABLE menu_items
+    DROP COLUMN category;
+
+-- +goose Down
+-- SQL in this section is executed when the migration is rolled back.
+
+DROP INDEX IF EXISTS idx_menu_items_category_id;
+
+ALTER TABLE menu_items
+    DROP COLUMN IF EXISTS category_id;
+
+ALTER TABLE menu_items
+    ADD COLUMN category TEXT;

--- a/internal/delivery/api/router/handler/menu_handler.go
+++ b/internal/delivery/api/router/handler/menu_handler.go
@@ -31,7 +31,7 @@ type MenuHandler struct {
 type CreateMenuItemRequest struct {
 	Name        string  `json:"name" validate:"required"`
 	Description *string `json:"description"`
-	Category    string  `json:"category" validate:"required,oneof=main snack drink dessert"`
+	CategoryID  string  `json:"category_id" validate:"required,uuid"`
 	Price       int     `json:"price" validate:"gte=0"`
 	Currency    string  `json:"currency" validate:"required"`
 	PrepMinutes int     `json:"prep_minutes" validate:"gt=0"`
@@ -44,7 +44,7 @@ type CreateMenuItemRequest struct {
 type UpdateMenuItemRequest struct {
 	Name        string  `json:"name" validate:"required"`
 	Description *string `json:"description"`
-	Category    string  `json:"category" validate:"required,oneof=main snack drink dessert"`
+	CategoryID  string  `json:"category_id" validate:"required,uuid"`
 	Price       int     `json:"price" validate:"gte=0"`
 	Currency    string  `json:"currency" validate:"required"`
 	PrepMinutes int     `json:"prep_minutes" validate:"gt=0"`
@@ -70,15 +70,15 @@ const (
 
 type ListMerchantMenuItemsQueryParams struct {
 	PaginationQueryParams
-	Category    string `query:"category"`
+	CategoryID  string `query:"category_id" validate:"omitempty,uuid"`
 	IsAvailable *bool  `query:"is_available"`
 	Keyword     string `query:"keyword"`
 }
 
 type ListPublicMerchantMenuItemsQueryParams struct {
 	PaginationQueryParams
-	Category string `query:"category"`
-	Keyword  string `query:"keyword"`
+	CategoryID string `query:"category_id" validate:"omitempty,uuid"`
+	Keyword    string `query:"keyword"`
 }
 
 func NewMenuHandler(params MenuHandlerParams) *MenuHandler {
@@ -142,11 +142,15 @@ func (h *MenuHandler) CreateMenuItem(c echo.Context) error {
 	if err := h.validateCreateMenuItemRequest(c, &req); err != nil {
 		return err
 	}
+	categoryID, err := uuid.Parse(req.CategoryID)
+	if err != nil {
+		return validationFailedError("category_id must be a valid UUID")
+	}
 
 	item, err := h.menuUC.CreateMenuItem(c.Request().Context(), merchantID, &usecase.CreateMenuItemInput{
 		Name:        req.Name,
 		Description: req.Description,
-		Category:    req.Category,
+		CategoryID:  categoryID,
 		Price:       req.Price,
 		Currency:    req.Currency,
 		PrepMinutes: req.PrepMinutes,
@@ -181,11 +185,15 @@ func (h *MenuHandler) UpdateMenuItem(c echo.Context) error {
 	if err := h.validateUpdateMenuItemRequest(c, &req); err != nil {
 		return err
 	}
+	categoryID, err := uuid.Parse(req.CategoryID)
+	if err != nil {
+		return validationFailedError("category_id must be a valid UUID")
+	}
 
 	item, err := h.menuUC.UpdateMenuItem(c.Request().Context(), merchantID, itemID, &usecase.UpdateMenuItemInput{
 		Name:        req.Name,
 		Description: req.Description,
-		Category:    req.Category,
+		CategoryID:  categoryID,
 		Price:       req.Price,
 		Currency:    req.Currency,
 		PrepMinutes: req.PrepMinutes,
@@ -289,11 +297,15 @@ func (h *MenuHandler) parseListMerchantMenuItemsInput(c echo.Context) (*usecase.
 	if err := validatePaginationQueryParams(c, &query.PaginationQueryParams); err != nil {
 		return nil, err
 	}
+	categoryID, err := parseOptionalUUIDQueryValue(c, "category_id", query.CategoryID)
+	if err != nil {
+		return nil, err
+	}
 
 	query.PageSize = min(query.PageSize, maxMenuItemsPageSize)
 
 	return &usecase.ListMerchantMenuItemsInput{
-		Category:    strings.TrimSpace(query.Category),
+		CategoryID:  categoryID,
 		IsAvailable: query.IsAvailable,
 		Keyword:     strings.TrimSpace(query.Keyword),
 		Page:        query.Page,
@@ -312,14 +324,18 @@ func (h *MenuHandler) parseListPublicMerchantMenuItemsInput(c echo.Context) (*us
 	if err := validatePaginationQueryParams(c, &query.PaginationQueryParams); err != nil {
 		return nil, err
 	}
+	categoryID, err := parseOptionalUUIDQueryValue(c, "category_id", query.CategoryID)
+	if err != nil {
+		return nil, err
+	}
 
 	query.PageSize = min(query.PageSize, maxMenuItemsPageSize)
 
 	return &usecase.ListMerchantMenuItemsInput{
-		Category: strings.TrimSpace(query.Category),
-		Keyword:  strings.TrimSpace(query.Keyword),
-		Page:     query.Page,
-		PageSize: query.PageSize,
+		CategoryID: categoryID,
+		Keyword:    strings.TrimSpace(query.Keyword),
+		Page:       query.Page,
+		PageSize:   query.PageSize,
 	}, nil
 }
 
@@ -346,20 +362,20 @@ func normalizePaginationQueryParams(c echo.Context, params *PaginationQueryParam
 }
 
 func (h *MenuHandler) validateCreateMenuItemRequest(c echo.Context, req *CreateMenuItemRequest) error {
-	return h.validateMenuItemRequest(c, req, &req.Name, &req.Category, &req.Currency, req.ImageURL, req.ExternalURL)
+	return h.validateMenuItemRequest(c, req, &req.Name, &req.CategoryID, &req.Currency, req.ImageURL, req.ExternalURL)
 }
 
 func (h *MenuHandler) validateUpdateMenuItemRequest(c echo.Context, req *UpdateMenuItemRequest) error {
-	return h.validateMenuItemRequest(c, req, &req.Name, &req.Category, &req.Currency, req.ImageURL, req.ExternalURL)
+	return h.validateMenuItemRequest(c, req, &req.Name, &req.CategoryID, &req.Currency, req.ImageURL, req.ExternalURL)
 }
 
 func (h *MenuHandler) validateMenuItemRequest(
 	c echo.Context,
 	req any,
-	name, category, currency *string,
+	name, categoryID, currency *string,
 	imageURL, externalURL *string,
 ) error {
-	normalizeMenuItemRequestFields(name, category, currency)
+	normalizeMenuItemRequestFields(name, categoryID, currency)
 	if err := validateRequest(c, req); err != nil {
 		return err
 	}
@@ -367,12 +383,12 @@ func (h *MenuHandler) validateMenuItemRequest(
 	return h.validateMenuItemRequestURLs(imageURL, externalURL)
 }
 
-func normalizeMenuItemRequestFields(name, category, currency *string) {
+func normalizeMenuItemRequestFields(name, categoryID, currency *string) {
 	if name != nil {
 		*name = strings.TrimSpace(*name)
 	}
-	if category != nil {
-		*category = strings.TrimSpace(*category)
+	if categoryID != nil {
+		*categoryID = strings.TrimSpace(*categoryID)
 	}
 	if currency != nil {
 		*currency = strings.TrimSpace(*currency)

--- a/internal/delivery/api/router/handler/menu_handler_test.go
+++ b/internal/delivery/api/router/handler/menu_handler_test.go
@@ -1,0 +1,40 @@
+package handler
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMenuHandler_ParseListMerchantMenuItemsInput_ParsesCategoryID(t *testing.T) {
+	categoryID := uuid.New()
+	handler := &MenuHandler{}
+	c, _ := newJSONContext(http.MethodGet, "/menus/merchant?category_id="+categoryID.String()+"&keyword=%20noodles%20", "")
+
+	input, err := handler.parseListMerchantMenuItemsInput(c)
+
+	require.NoError(t, err)
+	require.NotNil(t, input.CategoryID)
+	assert.Equal(t, categoryID, *input.CategoryID)
+	assert.Equal(t, "noodles", input.Keyword)
+}
+
+func TestMenuHandler_ValidateCreateMenuItemRequest_RequiresCategoryID(t *testing.T) {
+	handler := &MenuHandler{}
+	req := &CreateMenuItemRequest{
+		Name:        "Noodles",
+		Price:       120,
+		Currency:    "TWD",
+		PrepMinutes: 10,
+	}
+	c, rec := newJSONContext(http.MethodPost, "/menus/merchant", "")
+
+	err := handler.validateCreateMenuItemRequest(c, req)
+	writeTestErrorResponse(c, err)
+
+	require.Error(t, err)
+	assert.Contains(t, rec.Body.String(), "category_id")
+}

--- a/internal/domain/entity/menu.go
+++ b/internal/domain/entity/menu.go
@@ -6,46 +6,24 @@ import (
 	"github.com/google/uuid"
 )
 
-type MenuCategory string
-
-const (
-	MenuCategoryMain    MenuCategory = "main"
-	MenuCategorySnack   MenuCategory = "snack"
-	MenuCategoryDrink   MenuCategory = "drink"
-	MenuCategoryDessert MenuCategory = "dessert"
-)
-
 // CurrencyTWD indicates New Taiwan Dollar. Menu prices are stored in minor units;
 // for TWD the minor unit is currently the same as whole dollars used by the UI.
 const CurrencyTWD = "TWD"
 
-func (c MenuCategory) String() string {
-	return string(c)
-}
-
-func (c MenuCategory) IsValid() bool {
-	switch c {
-	case MenuCategoryMain, MenuCategorySnack, MenuCategoryDrink, MenuCategoryDessert:
-		return true
-	default:
-		return false
-	}
-}
-
 type MenuItem struct {
-	ID           uuid.UUID    `json:"id"`
-	MerchantID   uuid.UUID    `json:"merchant_id"`
-	Name         string       `json:"name"`
-	Description  *string      `json:"description"`
-	Category     MenuCategory `json:"category"`
-	Price        int          `json:"price"` // Base price stored in minor units before any future promotion or discount rules.
-	Currency     string       `json:"currency"`
-	PrepMinutes  int          `json:"prep_minutes"`
-	IsAvailable  bool         `json:"is_available"`
-	IsPopular    bool         `json:"is_popular"`
-	DisplayOrder int          `json:"display_order"`
-	ImageURL     *string      `json:"image_url"`
-	ExternalURL  *string      `json:"external_url"`
-	CreatedAt    time.Time    `json:"created_at"`
-	UpdatedAt    time.Time    `json:"updated_at"`
+	ID           uuid.UUID  `json:"id"`
+	MerchantID   uuid.UUID  `json:"merchant_id"`
+	Name         string     `json:"name"`
+	Description  *string    `json:"description"`
+	CategoryID   *uuid.UUID `json:"category_id"`
+	Price        int        `json:"price"` // Base price stored in minor units before any future promotion or discount rules.
+	Currency     string     `json:"currency"`
+	PrepMinutes  int        `json:"prep_minutes"`
+	IsAvailable  bool       `json:"is_available"`
+	IsPopular    bool       `json:"is_popular"`
+	DisplayOrder int        `json:"display_order"`
+	ImageURL     *string    `json:"image_url"`
+	ExternalURL  *string    `json:"external_url"`
+	CreatedAt    time.Time  `json:"created_at"`
+	UpdatedAt    time.Time  `json:"updated_at"`
 }

--- a/internal/domain/errors/merchant_errors.go
+++ b/internal/domain/errors/merchant_errors.go
@@ -10,7 +10,6 @@ var (
 	ErrMenuItemCreateFailed      = NewBaseError(http.StatusInternalServerError, "MENU_ITEM_CREATE_FAILED", "建立菜單品項失敗", "")
 	ErrMenuItemUpdateFailed      = NewBaseError(http.StatusInternalServerError, "MENU_ITEM_UPDATE_FAILED", "更新菜單品項失敗", "")
 	ErrMenuItemOrderConflict     = NewBaseError(http.StatusConflict, "MENU_ITEM_ORDER_CONFLICT", "菜單排序衝突", "")
-	ErrInvalidMenuCategory       = NewBaseError(http.StatusBadRequest, "INVALID_MENU_CATEGORY", "無效的菜單分類", "")
 	ErrSubscriptionNotFound      = NewBaseError(http.StatusNotFound, "SUBSCRIPTION_NOT_FOUND", "找不到訂閱資料", "")
 	ErrSubscriptionAlreadyExists = NewBaseError(
 		http.StatusConflict,

--- a/internal/domain/repository/menu_repository.go
+++ b/internal/domain/repository/menu_repository.go
@@ -9,7 +9,7 @@ import (
 )
 
 type MenuItemListFilter struct {
-	Category    *entity.MenuCategory
+	CategoryID  *uuid.UUID
 	IsAvailable *bool
 	Keyword     string
 	Limit       int

--- a/internal/infra/persistence/model/menu_item_model.go
+++ b/internal/infra/persistence/model/menu_item_model.go
@@ -8,19 +8,19 @@ import (
 )
 
 type MenuItemModel struct {
-	ID           uuid.UUID `gorm:"type:uuid;primary_key;default:uuid_generate_v7()"`
-	MerchantID   uuid.UUID `gorm:"type:uuid;not null;index:idx_menu_items_merchant_deleted,priority:1;uniqueIndex:idx_menu_items_merchant_display_order_active,priority:1,where:deleted_at IS NULL"`
-	Name         string    `gorm:"type:text;not null"`
-	Description  *string   `gorm:"type:text"`
-	Category     string    `gorm:"type:text;not null"`
-	Price        int       `gorm:"not null"` // Base price stored in minor units; promotion-adjusted prices should be modeled separately.
-	Currency     string    `gorm:"type:text;not null;default:'TWD'"`
-	PrepMinutes  int       `gorm:"not null"`
-	IsAvailable  bool      `gorm:"not null;default:true"`
-	IsPopular    bool      `gorm:"not null;default:false"`
-	DisplayOrder int       `gorm:"not null;uniqueIndex:idx_menu_items_merchant_display_order_active,priority:2,where:deleted_at IS NULL"`
-	ImageURL     *string   `gorm:"type:text"`
-	ExternalURL  *string   `gorm:"type:text"`
+	ID           uuid.UUID  `gorm:"type:uuid;primary_key;default:uuid_generate_v7()"`
+	MerchantID   uuid.UUID  `gorm:"type:uuid;not null;index:idx_menu_items_merchant_deleted,priority:1;uniqueIndex:idx_menu_items_merchant_display_order_active,priority:1,where:deleted_at IS NULL"`
+	Name         string     `gorm:"type:text;not null"`
+	Description  *string    `gorm:"type:text"`
+	CategoryID   *uuid.UUID `gorm:"type:uuid;index:idx_menu_items_category_id"`
+	Price        int        `gorm:"not null"` // Base price stored in minor units; promotion-adjusted prices should be modeled separately.
+	Currency     string     `gorm:"type:text;not null;default:'TWD'"`
+	PrepMinutes  int        `gorm:"not null"`
+	IsAvailable  bool       `gorm:"not null;default:true"`
+	IsPopular    bool       `gorm:"not null;default:false"`
+	DisplayOrder int        `gorm:"not null;uniqueIndex:idx_menu_items_merchant_display_order_active,priority:2,where:deleted_at IS NULL"`
+	ImageURL     *string    `gorm:"type:text"`
+	ExternalURL  *string    `gorm:"type:text"`
 	CreatedAt    time.Time
 	UpdatedAt    time.Time
 	DeletedAt    gorm.DeletedAt `gorm:"index:idx_menu_items_merchant_deleted,priority:2"`

--- a/internal/infra/persistence/postgres/menu_repository.go
+++ b/internal/infra/persistence/postgres/menu_repository.go
@@ -98,8 +98,8 @@ func (repo *menuRepository) ListMenuItemsByMerchant(ctx context.Context, merchan
 	menuItem := repo.q.MenuItemModel
 	conditions := []gen.Condition{menuItem.MerchantID.Eq(merchantID)}
 
-	if filter.Category != nil {
-		conditions = append(conditions, menuItem.Category.Eq(filter.Category.String()))
+	if filter.CategoryID != nil {
+		conditions = append(conditions, menuItem.CategoryID.Eq(*filter.CategoryID))
 	}
 	if filter.IsAvailable != nil {
 		conditions = append(conditions, menuItem.IsAvailable.Is(*filter.IsAvailable))
@@ -146,7 +146,7 @@ func (repo *menuRepository) UpdateMenuItem(ctx context.Context, item *entity.Men
 	assignments := []field.AssignExpr{
 		menuItem.Name.Value(item.Name),
 		nullableStringAssign(&menuItem.Description, item.Description),
-		menuItem.Category.Value(item.Category.String()),
+		menuItem.CategoryID.Value(item.CategoryID),
 		menuItem.Price.Value(item.Price),
 		menuItem.Currency.Value(item.Currency),
 		menuItem.PrepMinutes.Value(item.PrepMinutes),
@@ -454,7 +454,7 @@ func toMenuItemDomain(data *model.MenuItemModel) *entity.MenuItem {
 		MerchantID:   data.MerchantID,
 		Name:         data.Name,
 		Description:  data.Description,
-		Category:     entity.MenuCategory(data.Category),
+		CategoryID:   data.CategoryID,
 		Price:        data.Price,
 		Currency:     data.Currency,
 		PrepMinutes:  data.PrepMinutes,
@@ -478,7 +478,7 @@ func fromMenuItemDomain(data *entity.MenuItem) *model.MenuItemModel {
 		MerchantID:   data.MerchantID,
 		Name:         data.Name,
 		Description:  data.Description,
-		Category:     data.Category.String(),
+		CategoryID:   data.CategoryID,
 		Price:        data.Price,
 		Currency:     data.Currency,
 		PrepMinutes:  data.PrepMinutes,

--- a/internal/infra/persistence/postgres/query/menu_items.gen.go
+++ b/internal/infra/persistence/postgres/query/menu_items.gen.go
@@ -31,7 +31,7 @@ func newMenuItemModel(db *gorm.DB, opts ...gen.DOOption) menuItemModel {
 	_menuItemModel.MerchantID = field.NewField(tableName, "merchant_id")
 	_menuItemModel.Name = field.NewString(tableName, "name")
 	_menuItemModel.Description = field.NewString(tableName, "description")
-	_menuItemModel.Category = field.NewString(tableName, "category")
+	_menuItemModel.CategoryID = field.NewField(tableName, "category_id")
 	_menuItemModel.Price = field.NewInt(tableName, "price")
 	_menuItemModel.Currency = field.NewString(tableName, "currency")
 	_menuItemModel.PrepMinutes = field.NewInt(tableName, "prep_minutes")
@@ -57,7 +57,7 @@ type menuItemModel struct {
 	MerchantID   field.Field
 	Name         field.String
 	Description  field.String
-	Category     field.String
+	CategoryID   field.Field
 	Price        field.Int
 	Currency     field.String
 	PrepMinutes  field.Int
@@ -89,7 +89,7 @@ func (m *menuItemModel) updateTableName(table string) *menuItemModel {
 	m.MerchantID = field.NewField(table, "merchant_id")
 	m.Name = field.NewString(table, "name")
 	m.Description = field.NewString(table, "description")
-	m.Category = field.NewString(table, "category")
+	m.CategoryID = field.NewField(table, "category_id")
 	m.Price = field.NewInt(table, "price")
 	m.Currency = field.NewString(table, "currency")
 	m.PrepMinutes = field.NewInt(table, "prep_minutes")
@@ -134,7 +134,7 @@ func (m *menuItemModel) fillFieldMap() {
 	m.fieldMap["merchant_id"] = m.MerchantID
 	m.fieldMap["name"] = m.Name
 	m.fieldMap["description"] = m.Description
-	m.fieldMap["category"] = m.Category
+	m.fieldMap["category_id"] = m.CategoryID
 	m.fieldMap["price"] = m.Price
 	m.fieldMap["currency"] = m.Currency
 	m.fieldMap["prep_minutes"] = m.PrepMinutes

--- a/internal/usecase/impl/menu_service.go
+++ b/internal/usecase/impl/menu_service.go
@@ -125,12 +125,13 @@ func (s *menuService) CreateMenuItem(ctx context.Context, merchantID uuid.UUID, 
 		return nil, err
 	}
 
+	categoryID := input.CategoryID
 	item := &entity.MenuItem{
 		ID:          uuid.New(),
 		MerchantID:  merchantID,
 		Name:        name,
 		Description: description,
-		CategoryID:  &input.CategoryID,
+		CategoryID:  &categoryID,
 		Price:       input.Price,
 		Currency:    currency,
 		PrepMinutes: input.PrepMinutes,
@@ -172,9 +173,10 @@ func (s *menuService) UpdateMenuItem(ctx context.Context, merchantID, itemID uui
 		return nil, err
 	}
 
+	categoryID := input.CategoryID
 	item.Name = name
 	item.Description = description
-	item.CategoryID = &input.CategoryID
+	item.CategoryID = &categoryID
 	item.Price = input.Price
 	item.Currency = currency
 	item.PrepMinutes = input.PrepMinutes

--- a/internal/usecase/impl/menu_service.go
+++ b/internal/usecase/impl/menu_service.go
@@ -279,6 +279,10 @@ func (s *menuService) validateActiveMenuCategory(ctx context.Context, categoryID
 
 	subcategory, err := s.discoveryRepo.FindSubcategoryByID(ctx, categoryID)
 	if err != nil {
+		if errors.Is(err, domainerrors.ErrDiscoverySubcategoryNotFound) {
+			return domainerrors.ErrValidationFailed.WithDetails("category_id must reference an active discovery subcategory")
+		}
+
 		return err
 	}
 	if subcategory.Status != entity.DiscoveryStatusActive {

--- a/internal/usecase/impl/menu_service.go
+++ b/internal/usecase/impl/menu_service.go
@@ -17,21 +17,24 @@ import (
 )
 
 type menuService struct {
-	menuRepo repository.MenuRepository
-	userRepo repository.UserRepository
+	menuRepo      repository.MenuRepository
+	userRepo      repository.UserRepository
+	discoveryRepo repository.DiscoveryRepository
 }
 
 type MenuServiceParams struct {
 	fx.In
 
-	MenuRepo repository.MenuRepository
-	UserRepo repository.UserRepository
+	MenuRepo      repository.MenuRepository
+	UserRepo      repository.UserRepository
+	DiscoveryRepo repository.DiscoveryRepository
 }
 
 func NewMenuService(params MenuServiceParams) usecase.MenuUsecase {
 	return &menuService{
-		menuRepo: params.MenuRepo,
-		userRepo: params.UserRepo,
+		menuRepo:      params.MenuRepo,
+		userRepo:      params.UserRepo,
+		discoveryRepo: params.DiscoveryRepo,
 	}
 }
 
@@ -72,12 +75,11 @@ func (s *menuService) ListMerchantMenuItems(ctx context.Context, merchantID uuid
 	if keyword := strings.TrimSpace(input.Keyword); keyword != "" {
 		filter.Keyword = keyword
 	}
-	if input.Category != "" {
-		category := entity.MenuCategory(strings.TrimSpace(input.Category))
-		if !category.IsValid() {
-			return nil, domainerrors.ErrInvalidMenuCategory
+	if input.CategoryID != nil {
+		if err := s.validateActiveMenuCategory(ctx, *input.CategoryID); err != nil {
+			return nil, err
 		}
-		filter.Category = &category
+		filter.CategoryID = input.CategoryID
 	}
 
 	items, total, err := s.menuRepo.ListMenuItemsByMerchant(ctx, merchantID, filter)
@@ -110,14 +112,16 @@ func (s *menuService) CreateMenuItem(ctx context.Context, merchantID uuid.UUID, 
 		isPopular = *input.IsPopular
 	}
 
-	category := entity.MenuCategory(strings.TrimSpace(input.Category))
 	currency := strings.ToUpper(strings.TrimSpace(input.Currency))
 	name := strings.TrimSpace(input.Name)
 	description := normalizeOptionalString(input.Description)
 	imageURL := normalizeOptionalString(input.ImageURL)
 	externalURL := normalizeOptionalString(input.ExternalURL)
 
-	if err := validateMenuItemFields(name, description, category, input.Price, currency, input.PrepMinutes); err != nil {
+	if err := validateMenuItemFields(name, description, input.CategoryID, input.Price, currency, input.PrepMinutes); err != nil {
+		return nil, err
+	}
+	if err := s.validateActiveMenuCategory(ctx, input.CategoryID); err != nil {
 		return nil, err
 	}
 
@@ -126,7 +130,7 @@ func (s *menuService) CreateMenuItem(ctx context.Context, merchantID uuid.UUID, 
 		MerchantID:  merchantID,
 		Name:        name,
 		Description: description,
-		Category:    category,
+		CategoryID:  &input.CategoryID,
 		Price:       input.Price,
 		Currency:    currency,
 		PrepMinutes: input.PrepMinutes,
@@ -157,18 +161,20 @@ func (s *menuService) UpdateMenuItem(ctx context.Context, merchantID, itemID uui
 
 	name := strings.TrimSpace(input.Name)
 	description := normalizeOptionalString(input.Description)
-	category := entity.MenuCategory(strings.TrimSpace(input.Category))
 	currency := strings.ToUpper(strings.TrimSpace(input.Currency))
 	imageURL := normalizeOptionalString(input.ImageURL)
 	externalURL := normalizeOptionalString(input.ExternalURL)
 
-	if err := validateMenuItemFields(name, description, category, input.Price, currency, input.PrepMinutes); err != nil {
+	if err := validateMenuItemFields(name, description, input.CategoryID, input.Price, currency, input.PrepMinutes); err != nil {
+		return nil, err
+	}
+	if err := s.validateActiveMenuCategory(ctx, input.CategoryID); err != nil {
 		return nil, err
 	}
 
 	item.Name = name
 	item.Description = description
-	item.Category = category
+	item.CategoryID = &input.CategoryID
 	item.Price = input.Price
 	item.Currency = currency
 	item.PrepMinutes = input.PrepMinutes
@@ -266,6 +272,22 @@ func (s *menuService) validatePublicMerchant(ctx context.Context, merchantID uui
 	return nil
 }
 
+func (s *menuService) validateActiveMenuCategory(ctx context.Context, categoryID uuid.UUID) error {
+	if categoryID == uuid.Nil {
+		return domainerrors.ErrValidationFailed.WithDetails("category_id is required")
+	}
+
+	subcategory, err := s.discoveryRepo.FindSubcategoryByID(ctx, categoryID)
+	if err != nil {
+		return err
+	}
+	if subcategory.Status != entity.DiscoveryStatusActive {
+		return domainerrors.ErrValidationFailed.WithDetails("category_id must reference an active discovery subcategory")
+	}
+
+	return nil
+}
+
 func normalizeOptionalString(value *string) *string {
 	if value == nil {
 		return nil
@@ -279,7 +301,7 @@ func normalizeOptionalString(value *string) *string {
 	return &trimmed
 }
 
-func validateMenuItemFields(name string, description *string, category entity.MenuCategory, price int, currency string, prepMinutes int) error {
+func validateMenuItemFields(name string, description *string, categoryID uuid.UUID, price int, currency string, prepMinutes int) error {
 	if name == "" {
 		return domainerrors.ErrValidationFailed.WithDetails("name is required")
 	}
@@ -289,8 +311,8 @@ func validateMenuItemFields(name string, description *string, category entity.Me
 	if description != nil && utf8.RuneCountInString(*description) > 500 {
 		return domainerrors.ErrValidationFailed.WithDetails("description must be 500 characters or fewer")
 	}
-	if !category.IsValid() {
-		return domainerrors.ErrInvalidMenuCategory
+	if categoryID == uuid.Nil {
+		return domainerrors.ErrValidationFailed.WithDetails("category_id is required")
 	}
 	if price < 0 {
 		return domainerrors.ErrValidationFailed.WithDetails("price must be greater than or equal to zero")

--- a/internal/usecase/impl/menu_service_test.go
+++ b/internal/usecase/impl/menu_service_test.go
@@ -133,13 +133,49 @@ func TestMenuService_CreateMenuItem_InactiveCategory(t *testing.T) {
 	categoryID := uuid.New()
 	service := NewMenuService(MenuServiceParams{
 		MenuRepo: &menuRepositoryStub{
-			createMenuItemFunc: func(_ context.Context, _ *entity.MenuItem) error { return nil },
+			createMenuItemFunc: func(_ context.Context, _ *entity.MenuItem) error {
+				t.Fatal("repository should not be called for invalid category")
+
+				return nil
+			},
 		},
 		DiscoveryRepo: &discoveryRepositoryStub{
 			findSubcategoryByIDFunc: func(_ context.Context, id uuid.UUID) (*entity.DiscoverySubcategory, error) {
 				assert.Equal(t, categoryID, id)
 
 				return &entity.DiscoverySubcategory{ID: categoryID, Status: entity.DiscoveryStatusInactive}, nil
+			},
+		},
+	})
+
+	item, err := service.CreateMenuItem(context.Background(), uuid.New(), &usecase.CreateMenuItemInput{
+		Name:        "Combo",
+		CategoryID:  categoryID,
+		Price:       120,
+		Currency:    "TWD",
+		PrepMinutes: 10,
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, item)
+	assert.ErrorIs(t, err, domainerrors.ErrValidationFailed)
+}
+
+func TestMenuService_CreateMenuItem_MissingCategory(t *testing.T) {
+	categoryID := uuid.New()
+	service := NewMenuService(MenuServiceParams{
+		MenuRepo: &menuRepositoryStub{
+			createMenuItemFunc: func(_ context.Context, _ *entity.MenuItem) error {
+				t.Fatal("repository should not be called for invalid category")
+
+				return nil
+			},
+		},
+		DiscoveryRepo: &discoveryRepositoryStub{
+			findSubcategoryByIDFunc: func(_ context.Context, id uuid.UUID) (*entity.DiscoverySubcategory, error) {
+				assert.Equal(t, categoryID, id)
+
+				return nil, domainerrors.ErrDiscoverySubcategoryNotFound
 			},
 		},
 	})
@@ -210,6 +246,47 @@ func TestMenuService_UpdateMenuItem_PreservesDisplayOrder(t *testing.T) {
 	assert.Equal(t, "New Name", item.Name)
 	require.NotNil(t, item.CategoryID)
 	assert.Equal(t, categoryID, *item.CategoryID)
+}
+
+func TestMenuService_UpdateMenuItem_InactiveCategory(t *testing.T) {
+	merchantID := uuid.New()
+	itemID := uuid.New()
+	categoryID := uuid.New()
+	service := NewMenuService(MenuServiceParams{
+		MenuRepo: &menuRepositoryStub{
+			findMenuItemByIDFunc: func(_ context.Context, id uuid.UUID) (*entity.MenuItem, error) {
+				assert.Equal(t, itemID, id)
+
+				return &entity.MenuItem{ID: itemID, MerchantID: merchantID}, nil
+			},
+			updateMenuItemFunc: func(_ context.Context, _ *entity.MenuItem) error {
+				t.Fatal("repository should not be called for invalid category")
+
+				return nil
+			},
+		},
+		DiscoveryRepo: &discoveryRepositoryStub{
+			findSubcategoryByIDFunc: func(_ context.Context, id uuid.UUID) (*entity.DiscoverySubcategory, error) {
+				assert.Equal(t, categoryID, id)
+
+				return &entity.DiscoverySubcategory{ID: categoryID, Status: entity.DiscoveryStatusInactive}, nil
+			},
+		},
+	})
+
+	item, err := service.UpdateMenuItem(context.Background(), merchantID, itemID, &usecase.UpdateMenuItemInput{
+		Name:        "Combo",
+		CategoryID:  categoryID,
+		Price:       120,
+		Currency:    "TWD",
+		PrepMinutes: 10,
+		IsAvailable: true,
+		IsPopular:   false,
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, item)
+	assert.ErrorIs(t, err, domainerrors.ErrValidationFailed)
 }
 
 func TestMenuService_ReorderMenuItems_RequiresCompleteSnapshot(t *testing.T) {

--- a/internal/usecase/impl/menu_service_test.go
+++ b/internal/usecase/impl/menu_service_test.go
@@ -111,13 +111,15 @@ func TestMenuService_CreateMenuItem_Success(t *testing.T) {
 	}
 
 	service := NewMenuService(MenuServiceParams{MenuRepo: repo, DiscoveryRepo: discoveryRepo})
-	item, err := service.CreateMenuItem(ctx, merchantID, &usecase.CreateMenuItemInput{
+	input := &usecase.CreateMenuItemInput{
 		Name:        "  Beef Noodles  ",
 		CategoryID:  categoryID,
 		Price:       180,
 		Currency:    "twd",
 		PrepMinutes: 15,
-	})
+	}
+	item, err := service.CreateMenuItem(ctx, merchantID, input)
+	input.CategoryID = uuid.New()
 
 	require.NoError(t, err)
 	require.NotNil(t, item)
@@ -231,7 +233,7 @@ func TestMenuService_UpdateMenuItem_PreservesDisplayOrder(t *testing.T) {
 	}
 
 	service := NewMenuService(MenuServiceParams{MenuRepo: repo, DiscoveryRepo: discoveryRepo})
-	item, err := service.UpdateMenuItem(ctx, merchantID, itemID, &usecase.UpdateMenuItemInput{
+	input := &usecase.UpdateMenuItemInput{
 		Name:        "New Name",
 		CategoryID:  categoryID,
 		Price:       70,
@@ -239,7 +241,9 @@ func TestMenuService_UpdateMenuItem_PreservesDisplayOrder(t *testing.T) {
 		PrepMinutes: 6,
 		IsAvailable: true,
 		IsPopular:   false,
-	})
+	}
+	item, err := service.UpdateMenuItem(ctx, merchantID, itemID, input)
+	input.CategoryID = uuid.New()
 
 	require.NoError(t, err)
 	assert.Equal(t, 4, item.DisplayOrder)

--- a/internal/usecase/impl/menu_service_test.go
+++ b/internal/usecase/impl/menu_service_test.go
@@ -90,6 +90,7 @@ func (s *userRepositoryStub) Update(context.Context, *entity.User) error {
 func TestMenuService_CreateMenuItem_Success(t *testing.T) {
 	ctx := context.Background()
 	merchantID := uuid.New()
+	categoryID := uuid.New()
 	now := time.Now()
 
 	repo := &menuRepositoryStub{
@@ -101,11 +102,18 @@ func TestMenuService_CreateMenuItem_Success(t *testing.T) {
 			return nil
 		},
 	}
+	discoveryRepo := &discoveryRepositoryStub{
+		findSubcategoryByIDFunc: func(_ context.Context, id uuid.UUID) (*entity.DiscoverySubcategory, error) {
+			assert.Equal(t, categoryID, id)
 
-	service := NewMenuService(MenuServiceParams{MenuRepo: repo})
+			return &entity.DiscoverySubcategory{ID: categoryID, Status: entity.DiscoveryStatusActive}, nil
+		},
+	}
+
+	service := NewMenuService(MenuServiceParams{MenuRepo: repo, DiscoveryRepo: discoveryRepo})
 	item, err := service.CreateMenuItem(ctx, merchantID, &usecase.CreateMenuItemInput{
 		Name:        "  Beef Noodles  ",
-		Category:    "main",
+		CategoryID:  categoryID,
 		Price:       180,
 		Currency:    "twd",
 		PrepMinutes: 15,
@@ -115,21 +123,30 @@ func TestMenuService_CreateMenuItem_Success(t *testing.T) {
 	require.NotNil(t, item)
 	assert.Equal(t, merchantID, item.MerchantID)
 	assert.Equal(t, "Beef Noodles", item.Name)
-	assert.Equal(t, entity.MenuCategoryMain, item.Category)
+	require.NotNil(t, item.CategoryID)
+	assert.Equal(t, categoryID, *item.CategoryID)
 	assert.Equal(t, entity.CurrencyTWD, item.Currency)
 	assert.Equal(t, 3, item.DisplayOrder)
 }
 
-func TestMenuService_CreateMenuItem_InvalidCategory(t *testing.T) {
+func TestMenuService_CreateMenuItem_InactiveCategory(t *testing.T) {
+	categoryID := uuid.New()
 	service := NewMenuService(MenuServiceParams{
 		MenuRepo: &menuRepositoryStub{
 			createMenuItemFunc: func(_ context.Context, _ *entity.MenuItem) error { return nil },
+		},
+		DiscoveryRepo: &discoveryRepositoryStub{
+			findSubcategoryByIDFunc: func(_ context.Context, id uuid.UUID) (*entity.DiscoverySubcategory, error) {
+				assert.Equal(t, categoryID, id)
+
+				return &entity.DiscoverySubcategory{ID: categoryID, Status: entity.DiscoveryStatusInactive}, nil
+			},
 		},
 	})
 
 	item, err := service.CreateMenuItem(context.Background(), uuid.New(), &usecase.CreateMenuItemInput{
 		Name:        "Combo",
-		Category:    "combo",
+		CategoryID:  categoryID,
 		Price:       120,
 		Currency:    "TWD",
 		PrepMinutes: 10,
@@ -137,18 +154,19 @@ func TestMenuService_CreateMenuItem_InvalidCategory(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Nil(t, item)
-	assert.ErrorIs(t, err, domainerrors.ErrInvalidMenuCategory)
+	assert.ErrorIs(t, err, domainerrors.ErrValidationFailed)
 }
 
 func TestMenuService_UpdateMenuItem_PreservesDisplayOrder(t *testing.T) {
 	ctx := context.Background()
 	merchantID := uuid.New()
 	itemID := uuid.New()
+	categoryID := uuid.New()
 	existingItem := &entity.MenuItem{
 		ID:           itemID,
 		MerchantID:   merchantID,
 		Name:         "Old Name",
-		Category:     entity.MenuCategoryDrink,
+		CategoryID:   nil,
 		Currency:     entity.CurrencyTWD,
 		Price:        60,
 		PrepMinutes:  5,
@@ -168,11 +186,18 @@ func TestMenuService_UpdateMenuItem_PreservesDisplayOrder(t *testing.T) {
 			return nil
 		},
 	}
+	discoveryRepo := &discoveryRepositoryStub{
+		findSubcategoryByIDFunc: func(_ context.Context, id uuid.UUID) (*entity.DiscoverySubcategory, error) {
+			assert.Equal(t, categoryID, id)
 
-	service := NewMenuService(MenuServiceParams{MenuRepo: repo})
+			return &entity.DiscoverySubcategory{ID: categoryID, Status: entity.DiscoveryStatusActive}, nil
+		},
+	}
+
+	service := NewMenuService(MenuServiceParams{MenuRepo: repo, DiscoveryRepo: discoveryRepo})
 	item, err := service.UpdateMenuItem(ctx, merchantID, itemID, &usecase.UpdateMenuItemInput{
 		Name:        "New Name",
-		Category:    "drink",
+		CategoryID:  categoryID,
 		Price:       70,
 		Currency:    "TWD",
 		PrepMinutes: 6,
@@ -183,6 +208,8 @@ func TestMenuService_UpdateMenuItem_PreservesDisplayOrder(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 4, item.DisplayOrder)
 	assert.Equal(t, "New Name", item.Name)
+	require.NotNil(t, item.CategoryID)
+	assert.Equal(t, categoryID, *item.CategoryID)
 }
 
 func TestMenuService_ReorderMenuItems_RequiresCompleteSnapshot(t *testing.T) {
@@ -256,6 +283,7 @@ func TestMenuService_ReorderMenuItems_Success(t *testing.T) {
 func TestMenuService_GetPublicMerchantMenu_Success(t *testing.T) {
 	ctx := context.Background()
 	merchantID := uuid.New()
+	categoryID := uuid.New()
 	expectedItems := []*entity.MenuItem{
 		{ID: uuid.New(), MerchantID: merchantID, Name: "Beef Noodles", IsAvailable: true},
 	}
@@ -265,8 +293,8 @@ func TestMenuService_GetPublicMerchantMenu_Success(t *testing.T) {
 			assert.Equal(t, merchantID, id)
 			require.NotNil(t, filter.IsAvailable)
 			assert.True(t, *filter.IsAvailable)
-			require.NotNil(t, filter.Category)
-			assert.Equal(t, entity.MenuCategoryMain, *filter.Category)
+			require.NotNil(t, filter.CategoryID)
+			assert.Equal(t, categoryID, *filter.CategoryID)
 			assert.Equal(t, "beef", filter.Keyword)
 			assert.Equal(t, 20, filter.Limit)
 			assert.Equal(t, 0, filter.Offset)
@@ -284,17 +312,25 @@ func TestMenuService_GetPublicMerchantMenu_Success(t *testing.T) {
 			}, nil
 		},
 	}
+	discoveryRepo := &discoveryRepositoryStub{
+		findSubcategoryByIDFunc: func(_ context.Context, id uuid.UUID) (*entity.DiscoverySubcategory, error) {
+			assert.Equal(t, categoryID, id)
+
+			return &entity.DiscoverySubcategory{ID: categoryID, Status: entity.DiscoveryStatusActive}, nil
+		},
+	}
 
 	service := NewMenuService(MenuServiceParams{
-		MenuRepo: menuRepo,
-		UserRepo: userRepo,
+		MenuRepo:      menuRepo,
+		UserRepo:      userRepo,
+		DiscoveryRepo: discoveryRepo,
 	})
 
 	result, err := service.GetPublicMerchantMenu(ctx, merchantID, &usecase.ListMerchantMenuItemsInput{
-		Category: "  main  ",
-		Keyword:  "  beef  ",
-		Page:     1,
-		PageSize: 20,
+		CategoryID: &categoryID,
+		Keyword:    "  beef  ",
+		Page:       1,
+		PageSize:   20,
 	})
 
 	require.NoError(t, err)
@@ -371,6 +407,7 @@ func TestMenuService_GetPublicMerchantMenu_MerchantNotFound(t *testing.T) {
 func TestMenuService_ListMerchantMenuItems_Success(t *testing.T) {
 	ctx := context.Background()
 	merchantID := uuid.New()
+	categoryID := uuid.New()
 	isAvailable := true
 	expectedItems := []*entity.MenuItem{
 		{ID: uuid.New(), MerchantID: merchantID, Name: "Beef Noodles"},
@@ -381,8 +418,8 @@ func TestMenuService_ListMerchantMenuItems_Success(t *testing.T) {
 			assert.Equal(t, merchantID, id)
 			require.NotNil(t, filter.IsAvailable)
 			assert.True(t, *filter.IsAvailable)
-			require.NotNil(t, filter.Category)
-			assert.Equal(t, entity.MenuCategoryMain, *filter.Category)
+			require.NotNil(t, filter.CategoryID)
+			assert.Equal(t, categoryID, *filter.CategoryID)
 			assert.Equal(t, "beef", filter.Keyword)
 			assert.Equal(t, 5, filter.Limit)
 			assert.Equal(t, 5, filter.Offset)
@@ -390,10 +427,17 @@ func TestMenuService_ListMerchantMenuItems_Success(t *testing.T) {
 			return expectedItems, 7, nil
 		},
 	}
+	discoveryRepo := &discoveryRepositoryStub{
+		findSubcategoryByIDFunc: func(_ context.Context, id uuid.UUID) (*entity.DiscoverySubcategory, error) {
+			assert.Equal(t, categoryID, id)
 
-	service := NewMenuService(MenuServiceParams{MenuRepo: repo})
+			return &entity.DiscoverySubcategory{ID: categoryID, Status: entity.DiscoveryStatusActive}, nil
+		},
+	}
+
+	service := NewMenuService(MenuServiceParams{MenuRepo: repo, DiscoveryRepo: discoveryRepo})
 	result, err := service.ListMerchantMenuItems(ctx, merchantID, &usecase.ListMerchantMenuItemsInput{
-		Category:    "  main  ",
+		CategoryID:  &categoryID,
 		IsAvailable: &isAvailable,
 		Keyword:     "  beef  ",
 		Page:        2,
@@ -408,7 +452,8 @@ func TestMenuService_ListMerchantMenuItems_Success(t *testing.T) {
 	assert.EqualValues(t, 7, result.Pagination.Total)
 }
 
-func TestMenuService_ListMerchantMenuItems_InvalidCategory(t *testing.T) {
+func TestMenuService_ListMerchantMenuItems_InactiveCategory(t *testing.T) {
+	categoryID := uuid.New()
 	service := NewMenuService(MenuServiceParams{
 		MenuRepo: &menuRepositoryStub{
 			listMenuItemsByMerchantFunc: func(context.Context, uuid.UUID, repository.MenuItemListFilter) ([]*entity.MenuItem, int64, error) {
@@ -417,17 +462,51 @@ func TestMenuService_ListMerchantMenuItems_InvalidCategory(t *testing.T) {
 				return nil, 0, nil
 			},
 		},
+		DiscoveryRepo: &discoveryRepositoryStub{
+			findSubcategoryByIDFunc: func(_ context.Context, id uuid.UUID) (*entity.DiscoverySubcategory, error) {
+				assert.Equal(t, categoryID, id)
+
+				return &entity.DiscoverySubcategory{ID: categoryID, Status: entity.DiscoveryStatusInactive}, nil
+			},
+		},
 	})
 
 	result, err := service.ListMerchantMenuItems(context.Background(), uuid.New(), &usecase.ListMerchantMenuItemsInput{
-		Category: "combo",
-		Page:     1,
-		PageSize: 10,
+		CategoryID: &categoryID,
+		Page:       1,
+		PageSize:   10,
 	})
 
 	require.Error(t, err)
 	assert.Nil(t, result)
-	assert.ErrorIs(t, err, domainerrors.ErrInvalidMenuCategory)
+	assert.ErrorIs(t, err, domainerrors.ErrValidationFailed)
+}
+
+func TestMenuService_ListMerchantMenuItems_AllowsLegacyRowsWithoutCategoryFilter(t *testing.T) {
+	ctx := context.Background()
+	merchantID := uuid.New()
+	expectedItems := []*entity.MenuItem{
+		{ID: uuid.New(), MerchantID: merchantID, Name: "Legacy Item", CategoryID: nil},
+	}
+
+	repo := &menuRepositoryStub{
+		listMenuItemsByMerchantFunc: func(_ context.Context, id uuid.UUID, filter repository.MenuItemListFilter) ([]*entity.MenuItem, int64, error) {
+			assert.Equal(t, merchantID, id)
+			assert.Nil(t, filter.CategoryID)
+
+			return expectedItems, 1, nil
+		},
+	}
+
+	service := NewMenuService(MenuServiceParams{MenuRepo: repo})
+	result, err := service.ListMerchantMenuItems(ctx, merchantID, &usecase.ListMerchantMenuItemsInput{
+		Page:     1,
+		PageSize: 20,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, expectedItems, result.Items)
 }
 
 func TestMenuService_UpdateMenuItemStatus_Success(t *testing.T) {

--- a/internal/usecase/menu_usecase.go
+++ b/internal/usecase/menu_usecase.go
@@ -9,7 +9,7 @@ import (
 )
 
 type ListMerchantMenuItemsInput struct {
-	Category    string
+	CategoryID  *uuid.UUID
 	IsAvailable *bool
 	Keyword     string
 	Page        int
@@ -19,7 +19,7 @@ type ListMerchantMenuItemsInput struct {
 type CreateMenuItemInput struct {
 	Name        string
 	Description *string
-	Category    string
+	CategoryID  uuid.UUID
 	Price       int
 	Currency    string
 	PrepMinutes int
@@ -32,7 +32,7 @@ type CreateMenuItemInput struct {
 type UpdateMenuItemInput struct {
 	Name        string
 	Description *string
-	Category    string
+	CategoryID  uuid.UUID
 	Price       int
 	Currency    string
 	PrepMinutes int


### PR DESCRIPTION
## Summary

- Replace hard-coded menu item categories with discovery subcategory IDs.
- Add a menu_items.category_id migration without a foreign key and drop the old category column.
- Validate active discovery subcategories in the menu usecase and update focused tests.

## Verification

- [x] `go test ./internal/usecase/impl ./internal/delivery/api/router/handler ./internal/infra/persistence/postgres`
- [x] `go test ./cmd/radar ./internal/delivery/api/router`
- [x] `git diff --check`

## Checklist

- [x] If this PR adds or changes PostgreSQL functions, I checked whether a Supabase post-migration hardening change is required. Not applicable: no PostgreSQL functions changed.
- [x] If this PR changes extension, PostGIS, or database `search_path` behavior, I checked the Supabase migration workflow and README guidance. Not applicable: no extension, PostGIS, or `search_path` behavior changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Menu item category handling now uses `category_id` (UUID) for create, update, and listings.
  * Listing endpoints accept `category_id` as an optional filter.
* **Bug Fixes**
  * Validation updated to require a valid UUID and only allow active discovery subcategories.
  * API error responses now reference `category_id` when missing/invalid.
* **Database Updates**
  * Added `category_id` UUID storage (with indexing) and removed the legacy category string.
* **Tests**
  * Updated unit tests for `category_id` parsing, normalization, and inactive/missing-category scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->