### PR TITLE
ci: upgrade github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Go version
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
@@ -50,7 +50,7 @@ jobs:
       image_name: ${{ steps.set-vars.outputs.IMAGE_NAME }}
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -66,7 +66,7 @@ jobs:
 
       - name: Detect changed paths
         id: changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
           base: ${{ github.event.before }}
           ref: ${{ github.sha }}
@@ -110,11 +110,11 @@ jobs:
 
       - name: Set up Docker Buildx
         if: steps.build-flags.outputs.any == 'true'
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build Radar image
         if: steps.build-flags.outputs.radar == 'true'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
@@ -142,7 +142,7 @@ jobs:
 
       - name: Upload Radar image artifact
         if: steps.build-flags.outputs.radar == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: radar-image
           path: /tmp/radar-image.tar
@@ -150,7 +150,7 @@ jobs:
 
       - name: Build Geoworker image
         if: steps.build-flags.outputs.geoworker == 'true'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
@@ -174,7 +174,7 @@ jobs:
 
       - name: Build Device Cleanup image
         if: steps.build-flags.outputs.device_cleanup == 'true'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
@@ -202,7 +202,7 @@ jobs:
 
       - name: Upload Device Cleanup image artifact
         if: steps.build-flags.outputs.device_cleanup == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: device-cleanup-image
           path: /tmp/device-cleanup-image.tar
@@ -214,7 +214,7 @@ jobs:
 
       - name: Upload Geoworker image artifact
         if: steps.build-flags.outputs.geoworker == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: geoworker-image
           path: /tmp/geoworker-image.tar
@@ -246,32 +246,32 @@ jobs:
 
       - name: Download Radar image artifact
         if: needs.build-images.outputs.radar == 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: radar-image
           path: /tmp
 
       - name: Download Geoworker image artifact
         if: needs.build-images.outputs.geoworker == 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: geoworker-image
           path: /tmp
 
       - name: Download Device Cleanup image artifact
         if: needs.build-images.outputs.device_cleanup == 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: device-cleanup-image
           path: /tmp
 
       - name: Google Auth (dev)
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: "${{ secrets.GCP_DEV_SA_KEY }}"
 
       - name: Set up Cloud SDK (dev)
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
         with:
           project_id: ${{ env.PROJECT_ID }}
 
@@ -340,32 +340,32 @@ jobs:
 
       - name: Download Radar image artifact
         if: needs.build-images.outputs.radar == 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: radar-image
           path: /tmp
 
       - name: Download Geoworker image artifact
         if: needs.build-images.outputs.geoworker == 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: geoworker-image
           path: /tmp
 
       - name: Download Device Cleanup image artifact
         if: needs.build-images.outputs.device_cleanup == 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: device-cleanup-image
           path: /tmp
 
       - name: Google Auth (prod)
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: "${{ secrets.GCP_PROD_SA_KEY }}"
 
       - name: Set up Cloud SDK (prod)
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
         with:
           project_id: ${{ env.PROJECT_ID }}
 

--- a/.github/workflows/deploy-cloud-run-reusable.yml
+++ b/.github/workflows/deploy-cloud-run-reusable.yml
@@ -127,14 +127,14 @@ jobs:
           done
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: refs/heads/main
           fetch-depth: 0
 
       - name: Set up Go version
         if: ${{ inputs.run_migration || inputs.run_supabase_migration }}
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
@@ -142,12 +142,12 @@ jobs:
 
       - name: Google Auth
         id: auth
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: "${{ secrets.GCP_SA_KEY }}"
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
         with:
           project_id: ${{ env.PROJECT_ID }}
 


### PR DESCRIPTION
## Summary

- Upgrade GitHub Actions to current major versions that use Node.js 24.
- Keep existing workflow inputs and deployment behavior unchanged.
- Leave golangci/golangci-lint-action on v9 because it is already on the latest major.

## Verification

- Manually checked that the old action versions no longer remain in workflow files.
- Did not run Go tests because this is a workflow metadata-only change.

## Checklist

- [x] If this PR adds or changes PostgreSQL functions, I checked whether a Supabase post-migration hardening change is required. Not applicable; workflow-only change.
- [x] If this PR changes extension, PostGIS, or database `search_path` behavior, I checked the Supabase migration workflow and README guidance. Not applicable; workflow-only change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated several GitHub Actions used in CI, artifact handling, Docker publishing, and Cloud Run deployment.
  * Brought Google Cloud setup/auth steps to newer versions for dev and production release workflows.
  * No build, test, or deployment behavior changed; these updates are focused on keeping automation current and reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->