### PR TITLE
fix: recover Cloud Run releases and support pinned deployments

### DIFF
--- a/.github/scripts/release/not_found.sh
+++ b/.github/scripts/release/not_found.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Only a real gcloud NOT_FOUND status may authorize a create/publish fallback.
+not_found_status() {
+  grep -Eq '(^|[[:space:]])NOT_FOUND([:[:space:]]|$)' "$1"
+}

--- a/.github/scripts/release/release.sh
+++ b/.github/scripts/release/release.sh
@@ -122,7 +122,7 @@ resolve_candidate_image() {
     --project="${DEV_PROJECT_ID}" --format='value(image_summary.fully_qualified_digest)' 2>"${error_file}"); then
     rm -f "${error_file}"
   else
-    if grep -Eiq 'not[[:space:]_-]*found|NOT_FOUND|does not exist|could not find|resource.*missing' "${error_file}"; then
+    if grep -Eiq 'NOT_FOUND|not[[:space:]_-]*found|does not exist|cannot find|could not find|resource.*missing' "${error_file}"; then
       rm -f "${error_file}"
       return 1
     fi
@@ -207,7 +207,7 @@ validate_bundle() {
   ' "${BUNDLE_FILE}" >/dev/null || die 'invalid release bundle'
 }
 
-not_found() { grep -Eiq 'NOT_FOUND|not found|does not exist' "$1"; }
+not_found() { grep -Eiq 'NOT_FOUND|not[[:space:]_-]*found|does not exist|cannot find|could not find|resource.*missing' "$1"; }
 
 describe_resource() {
   type=$1 name=$2
@@ -269,8 +269,10 @@ snapshot() {
   required PROJECT_ID REGION
   state='{}'
   while IFS= read -r target; do
-    kind=$(target_kind "${target}")
-    resource=$(describe_resource "${kind}" "${target}")
+    kind=$(target_kind "${target}") \
+      || die "cannot resolve kind for ${target}"
+    resource=$(describe_resource "${kind}" "${target}") \
+      || die "cannot snapshot ${target}"
     state=$(jq -c --arg target "${target}" --argjson resource "${resource}" '. + {($target):$resource}' <<<"${state}")
   done < <(target_names)
   printf '%s\n' "${state}"
@@ -295,7 +297,7 @@ preflight() {
   required RELEASE_SHA
   is_sha "${RELEASE_SHA}" || die 'invalid RELEASE_SHA'
   validate_bundle
-  state=$(snapshot)
+  state=$(snapshot) || die 'cannot snapshot Cloud Run state'
   expected_targets=$(jq -c 'keys | sort' "$(targets_file)")
   jq -e --argjson expected_targets "${expected_targets}" \
     '(keys | sort) == $expected_targets and all(.[]; has("exists") and has("label"))' \

--- a/.github/scripts/release/release.sh
+++ b/.github/scripts/release/release.sh
@@ -8,6 +8,8 @@ set -euo pipefail
 repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/../../.." && pwd)
 default_targets_file="${repo_root}/.github/scripts/release/targets.json"
 default_impact_paths_file="${repo_root}/.github/scripts/release/impact-paths.txt"
+# shellcheck source=.github/scripts/release/not_found.sh
+source "${repo_root}/.github/scripts/release/not_found.sh"
 
 die() { printf 'release: %s\n' "$*" >&2; exit 1; }
 integrity_die() { printf 'release: %s\n' "$*" >&2; exit 3; }
@@ -122,7 +124,7 @@ resolve_candidate_image() {
     --project="${DEV_PROJECT_ID}" --format='value(image_summary.fully_qualified_digest)' 2>"${error_file}"); then
     rm -f "${error_file}"
   else
-    if grep -Eiq 'NOT_FOUND|not[[:space:]_-]*found|does not exist|cannot find|could not find|resource.*missing' "${error_file}"; then
+    if not_found_status "${error_file}"; then
       rm -f "${error_file}"
       return 1
     fi
@@ -220,14 +222,14 @@ validate_bundle() {
   ' "${BUNDLE_FILE}" >/dev/null || die 'invalid release bundle'
 }
 
-not_found() { grep -Eiq 'NOT_FOUND|not[[:space:]_-]*found|does not exist|cannot find|could not find|resource.*missing' "$1"; }
+not_found() { not_found_status "$3" || grep -Fqi "Cannot find $1 [$2]" "$3"; }
 
 describe_resource() {
   type=$1 name=$2
   error_file=$(mktemp "${RUNNER_TEMP:-/tmp}/release-error.XXXXXX")
   if [ "${type}" = service ]; then
     if ! json=$(gcloud run services describe "${name}" --project="${PROJECT_ID}" --region="${REGION}" --format=json 2>"${error_file}"); then
-      if not_found "${error_file}"; then
+      if not_found "${type}" "${name}" "${error_file}"; then
         rm -f "${error_file}"
         jq -cn '{exists:false,label:"",desired_label:"",ready:false,image:""}'
         return
@@ -246,7 +248,7 @@ describe_resource() {
         rm -f "${revision_error}"
         label=$(jq -r '.metadata.labels["release-sha"] // .spec.template.metadata.labels["release-sha"] // ""' <<<"${revision_json}")
         image=$(jq -r '.spec.containers[0].image // .spec.template.spec.containers[0].image // ""' <<<"${revision_json}")
-      elif not_found "${revision_error}"; then
+      elif not_found revision "${revision}" "${revision_error}"; then
         rm -f "${revision_error}"
         ready=False
       else
@@ -260,7 +262,7 @@ describe_resource() {
       '{exists:true,label:$label,desired_label:$desired,ready:$ready,image:$image}'
   else
     if ! json=$(gcloud run jobs describe "${name}" --project="${PROJECT_ID}" --region="${REGION}" --format=json 2>"${error_file}"); then
-      if not_found "${error_file}"; then
+      if not_found "${type}" "${name}" "${error_file}"; then
         rm -f "${error_file}"
         jq -cn '{exists:false,label:"",desired_label:"",ready:true,image:""}'
         return

--- a/.github/scripts/release/release.sh
+++ b/.github/scripts/release/release.sh
@@ -306,13 +306,16 @@ baseline_digest() {
     --project="${PROJECT_ID}" --format='value(image_summary.fully_qualified_digest)'
 }
 
+# A pinned release may move backwards, so its baseline only has to be
+# comparable; an unpinned release must move strictly forward.
 baseline_is_compatible() {
+  candidate_baseline=$1
   if [ -n "${REQUESTED_SHA:-}" ]; then
-    git merge-base --is-ancestor "${baseline}" "${CONTROL_SHA}" || return 1
-    git merge-base --is-ancestor "${baseline}" "${RELEASE_SHA}" \
-      || git merge-base --is-ancestor "${RELEASE_SHA}" "${baseline}"
+    git merge-base --is-ancestor "${candidate_baseline}" "${CONTROL_SHA}" || return 1
+    git merge-base --is-ancestor "${candidate_baseline}" "${RELEASE_SHA}" \
+      || git merge-base --is-ancestor "${RELEASE_SHA}" "${candidate_baseline}"
   else
-    git merge-base --is-ancestor "${baseline}" "${RELEASE_SHA}"
+    git merge-base --is-ancestor "${candidate_baseline}" "${RELEASE_SHA}"
   fi
 }
 
@@ -379,26 +382,14 @@ preflight() {
       || die 'missing or unlabeled resources are accepted only for a target-SHA retry'
   elif [ "${count}" -eq 1 ]; then
     baseline=$(jq -r '.[0]' <<<"${labels}")
-    if [ "${baseline}" = "${RELEASE_SHA}" ]; then
-      :
-    else
-      if [ -n "${REQUESTED_SHA:-}" ]; then
-        baseline_is_compatible \
-          || die 'pinned release is not compatible with the current target baseline'
-      else
-        git merge-base --is-ancestor "${baseline}" "${RELEASE_SHA}" \
-          || die 'target is not a forward release from the current baseline'
-      fi
+    if [ "${baseline}" != "${RELEASE_SHA}" ]; then
+      baseline_is_compatible "${baseline}" \
+        || die "release is not compatible with the current target baseline ${baseline}"
     fi
   elif [ "${count}" -eq 2 ] && jq -e --arg target "${RELEASE_SHA}" 'index($target) != null' <<<"${labels}" >/dev/null; then
     baseline=$(jq -r --arg target "${RELEASE_SHA}" '.[] | select(. != $target)' <<<"${labels}")
-    if [ -n "${REQUESTED_SHA:-}" ]; then
-      baseline_is_compatible \
-        || die 'pinned release is not compatible with the partial target baseline'
-    else
-      git merge-base --is-ancestor "${baseline}" "${RELEASE_SHA}" \
-        || die 'partial release baseline is not an ancestor of target'
-    fi
+    baseline_is_compatible "${baseline}" \
+      || die "release is not compatible with the partial target baseline ${baseline}"
   else
     die 'Cloud Run resources have divergent release state'
   fi

--- a/.github/scripts/release/release.sh
+++ b/.github/scripts/release/release.sh
@@ -222,7 +222,14 @@ validate_bundle() {
   ' "${BUNDLE_FILE}" >/dev/null || die 'invalid release bundle'
 }
 
-not_found() { not_found_status "$3" || grep -Fqi "Cannot find $1 [$2]" "$3"; }
+not_found() {
+  not_found_status "$3" && return 0
+  # Cloud Run renders not-found without a status token. Explicitly reject
+  # other gcloud status codes before accepting its resource-specific wording.
+  grep -Eq '(^|[[:space:]])(PERMISSION_DENIED|UNAUTHENTICATED|INVALID_ARGUMENT|FAILED_PRECONDITION|RESOURCE_EXHAUSTED|UNAVAILABLE|INTERNAL|ABORTED|UNKNOWN)([:[:space:]]|$)' "$3" \
+    && return 1
+  grep -Fqi "Cannot find $1 [$2]" "$3"
+}
 
 describe_resource() {
   type=$1 name=$2

--- a/.github/scripts/release/release.sh
+++ b/.github/scripts/release/release.sh
@@ -151,18 +151,28 @@ resolve_candidate() {
   done < <(impact_path_args)
   test "${#path_args[@]}" -gt 0 || die 'impact path manifest is empty'
 
-  candidates=$(git rev-list --first-parent --max-count=50 "${CONTROL_SHA}") \
-    || die "git rev-list failed while scanning candidates"
-  test -n "${candidates}" || die 'git rev-list returned no candidates'
+  if [ -n "${REQUESTED_SHA:-}" ]; then
+    is_sha "${REQUESTED_SHA}" || die 'invalid REQUESTED_SHA'
+    git cat-file -e "${REQUESTED_SHA}^{commit}" || die 'REQUESTED_SHA is not available locally'
+    git merge-base --is-ancestor "${REQUESTED_SHA}" "${CONTROL_SHA}" \
+      || die 'REQUESTED_SHA is not an ancestor of the current main control commit'
+    candidates="${REQUESTED_SHA}"
+  else
+    candidates=$(git rev-list --first-parent --max-count=50 "${CONTROL_SHA}") \
+      || die "git rev-list failed while scanning candidates"
+    test -n "${candidates}" || die 'git rev-list returned no candidates'
+  fi
   while IFS= read -r candidate <&3; do
     # A candidate can only be promoted when everything after it is outside the
     # release contract. This is what permits docs-only commits without rebuilds.
-    if git diff --quiet "${candidate}..${CONTROL_SHA}" -- "${path_args[@]}"; then
-      :
-    else
-      diff_status=$?
-      [ "${diff_status}" -eq 1 ] || die "git diff failed while scanning candidate ${candidate}"
-      continue
+    if [ -z "${REQUESTED_SHA:-}" ]; then
+      if git diff --quiet "${candidate}..${CONTROL_SHA}" -- "${path_args[@]}"; then
+        :
+      else
+        diff_status=$?
+        [ "${diff_status}" -eq 1 ] || die "git diff failed while scanning candidate ${candidate}"
+        continue
+      fi
     fi
     images='{}'
     complete=true
@@ -190,6 +200,9 @@ resolve_candidate() {
     printf 'release_sha=%s\npath=%s\n' "${candidate}" "${bundle}" >> "${GITHUB_OUTPUT:-/dev/stdout}"
     return 0
   done 3<<<"${candidates}"
+  if [ -n "${REQUESTED_SHA:-}" ]; then
+    die "pinned candidate ${REQUESTED_SHA} has no complete attested image set"
+  fi
   die 'no complete candidate ancestor is compatible with the current main control commit'
 }
 
@@ -293,9 +306,27 @@ baseline_digest() {
     --project="${PROJECT_ID}" --format='value(image_summary.fully_qualified_digest)'
 }
 
+baseline_is_compatible() {
+  if [ -n "${REQUESTED_SHA:-}" ]; then
+    git merge-base --is-ancestor "${baseline}" "${CONTROL_SHA}" || return 1
+    git merge-base --is-ancestor "${baseline}" "${RELEASE_SHA}" \
+      || git merge-base --is-ancestor "${RELEASE_SHA}" "${baseline}"
+  else
+    git merge-base --is-ancestor "${baseline}" "${RELEASE_SHA}"
+  fi
+}
+
 preflight() {
   required RELEASE_SHA
   is_sha "${RELEASE_SHA}" || die 'invalid RELEASE_SHA'
+  if [ -n "${REQUESTED_SHA:-}" ]; then
+    required CONTROL_SHA
+    is_sha "${CONTROL_SHA}" || die 'invalid CONTROL_SHA'
+    [ "${REQUESTED_SHA}" = "${RELEASE_SHA}" ] || die 'pinned release SHA does not match REQUESTED_SHA'
+    git cat-file -e "${CONTROL_SHA}^{commit}" || die 'CONTROL_SHA is not available locally'
+    git merge-base --is-ancestor "${RELEASE_SHA}" "${CONTROL_SHA}" \
+      || die 'pinned RELEASE_SHA is not an ancestor of the current main control commit'
+  fi
   validate_bundle
   state=$(snapshot) || die 'cannot snapshot Cloud Run state'
   expected_targets=$(jq -c 'keys | sort' "$(targets_file)")
@@ -351,13 +382,23 @@ preflight() {
     if [ "${baseline}" = "${RELEASE_SHA}" ]; then
       :
     else
-      git merge-base --is-ancestor "${baseline}" "${RELEASE_SHA}" \
-        || die 'target is not a forward release from the current baseline'
+      if [ -n "${REQUESTED_SHA:-}" ]; then
+        baseline_is_compatible \
+          || die 'pinned release is not compatible with the current target baseline'
+      else
+        git merge-base --is-ancestor "${baseline}" "${RELEASE_SHA}" \
+          || die 'target is not a forward release from the current baseline'
+      fi
     fi
   elif [ "${count}" -eq 2 ] && jq -e --arg target "${RELEASE_SHA}" 'index($target) != null' <<<"${labels}" >/dev/null; then
     baseline=$(jq -r --arg target "${RELEASE_SHA}" '.[] | select(. != $target)' <<<"${labels}")
-    git merge-base --is-ancestor "${baseline}" "${RELEASE_SHA}" \
-      || die 'partial release baseline is not an ancestor of target'
+    if [ -n "${REQUESTED_SHA:-}" ]; then
+      baseline_is_compatible \
+        || die 'pinned release is not compatible with the partial target baseline'
+    else
+      git merge-base --is-ancestor "${baseline}" "${RELEASE_SHA}" \
+        || die 'partial release baseline is not an ancestor of target'
+    fi
   else
     die 'Cloud Run resources have divergent release state'
   fi

--- a/.github/scripts/release/release_test.sh
+++ b/.github/scripts/release/release_test.sh
@@ -8,6 +8,21 @@ temp_dir=$(mktemp -d "${TMPDIR:-/tmp}/nomnom-release-test.XXXXXX")
 trap 'rm -rf "${temp_dir}"' EXIT HUP INT TERM
 
 fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+# shellcheck source=.github/scripts/release/not_found.sh
+source "${repo_root}/.github/scripts/release/not_found.sh"
+
+status_fixture="${temp_dir}/not-found-status.txt"
+printf 'ERROR: (gcloud.artifacts.docker.images.describe) NOT_FOUND: image was not found.\n' > "${status_fixture}"
+not_found_status "${status_fixture}" || fail not-found-status
+printf 'ERROR: (gcloud...) PERMISSION_DENIED: Could not find valid credentials.\n' > "${status_fixture}"
+if not_found_status "${status_fixture}"; then
+  fail permission-error-not-not-found
+fi
+printf 'ERROR: (gcloud...) INVALID_ARGUMENT: The requested location does not exist.\n' > "${status_fixture}"
+if not_found_status "${status_fixture}"; then
+  fail invalid-argument-not-not-found
+fi
+
 git_dir="${temp_dir}/git"
 git init -q "${git_dir}"
 git -C "${git_dir}" config user.email test@example.invalid
@@ -235,7 +250,7 @@ if [ -n "${MOCK_DESCRIBE_ERROR_TARGET:-}" ] \
   && { [ "${2:-}" = jobs ] || [ "${2:-}" = services ]; } \
   && [ "${3:-}" = describe ] \
   && [ "${4:-}" = "${MOCK_DESCRIBE_ERROR_TARGET}" ]; then
-  printf 'ERROR: (gcloud.run.%s.describe) PERMISSION_DENIED: test failure for %s.\n' \
+  printf 'ERROR: (gcloud.run.%s.describe) PERMISSION_DENIED: Could not find valid credentials for %s.\n' \
     "${2}" "${4}" >&2
   exit 1
 fi

--- a/.github/scripts/release/release_test.sh
+++ b/.github/scripts/release/release_test.sh
@@ -245,6 +245,16 @@ if [ -n "${MOCK_MISSING_TARGET:-}" ] \
     "${2}" "${resource_kind}" "${4}" >&2
   exit 1
 fi
+if [ -n "${MOCK_STATUS_COLLISION_TARGET:-}" ] \
+  && [ "${1:-}" = run ] \
+  && { [ "${2:-}" = jobs ] || [ "${2:-}" = services ]; } \
+  && [ "${3:-}" = describe ] \
+  && [ "${4:-}" = "${MOCK_STATUS_COLLISION_TARGET}" ]; then
+  resource_kind=${2%s}
+  printf 'ERROR: (gcloud.run.%s.describe) PERMISSION_DENIED: Cannot find %s [%s].\n' \
+    "${2}" "${resource_kind}" "${4}" >&2
+  exit 1
+fi
 if [ -n "${MOCK_DESCRIBE_ERROR_TARGET:-}" ] \
   && [ "${1:-}" = run ] \
   && { [ "${2:-}" = jobs ] || [ "${2:-}" = services ]; } \
@@ -306,6 +316,17 @@ grep -F 'cannot snapshot device-cleanup' "${describe_error_output}" >/dev/null \
   || fail describe-error-source-message
 if grep -F 'invalid Cloud Run state' "${describe_error_output}" >/dev/null; then
   fail describe-error-reached-jq
+fi
+status_collision_output="${temp_dir}/status-collision-preflight.txt"
+if env "${common_env[@]}" MOCK_SHA="${sha}" MOCK_RADAR="${digest_a}" MOCK_GEOWORKER="${digest_b}" MOCK_CLEANUP="${digest_c}" \
+  MOCK_STATUS_COLLISION_TARGET=device-cleanup \
+  bash "${script_dir}/release.sh" preflight >"${status_collision_output}" 2>&1; then
+  fail status-collision-preflight-open
+fi
+grep -F 'cannot snapshot device-cleanup' "${status_collision_output}" >/dev/null \
+  || fail status-collision-source-message
+if grep -F 'invalid Cloud Run state' "${status_collision_output}" >/dev/null; then
+  fail status-collision-reached-jq
 fi
 env "${common_env[@]}" TARGET_ENVIRONMENT=dev bash "${script_dir}/release.sh" deploy
 env "${common_env[@]}" TARGET_ENVIRONMENT=prod CLOUDFLARE_ORIGIN_SECRET='safe/+value=' bash "${script_dir}/release.sh" deploy
@@ -676,10 +697,19 @@ MOCK
 cat > "${promote_runner}/gcrane/gcrane" <<'MOCK'
 #!/usr/bin/env bash
 set -euo pipefail
+if [ "${1:-}" != copy ] \
+  || [ "${2:-}" != "${MOCK_PROMOTE_EXPECTED_SOURCE}" ] \
+  || [ "${3:-}" != "${MOCK_PROMOTE_EXPECTED_DESTINATION}" ] \
+  || [ "$#" -ne 3 ]; then
+  printf 'unexpected gcrane invocation: %s\n' "$*" >&2
+  exit 1
+fi
 : > "${MOCK_PROMOTE_COPY_MARKER}"
 MOCK
 chmod +x "${promote_bin}/gcloud" "${promote_runner}/gcrane/gcrane"
 promote_image="prod.example/repo/radar@sha256:$(printf 'a%.0s' {1..64})"
+promote_source="${digest_a}"
+promote_destination="prod.example/repo/radar:${sha}"
 run_promote() {
   local error_mode=$1 copy_marker=$2 describe_count=$3 output_file=$4
   (
@@ -690,6 +720,7 @@ run_promote() {
       RUNNER_TEMP="${promote_runner}" GITHUB_OUTPUT="${output_file}" \
       MOCK_PROMOTE_ERROR="${error_mode}" MOCK_PROMOTE_COPY_MARKER="${copy_marker}" \
       MOCK_PROMOTE_DESCRIBE_COUNT="${describe_count}" MOCK_PROMOTE_IMAGE="${promote_image}" \
+      MOCK_PROMOTE_EXPECTED_SOURCE="${promote_source}" MOCK_PROMOTE_EXPECTED_DESTINATION="${promote_destination}" \
       bash "${promote_run}"
   )
 }

--- a/.github/scripts/release/release_test.sh
+++ b/.github/scripts/release/release_test.sh
@@ -761,6 +761,14 @@ ruby -ryaml -e '
   operation_steps = operation.fetch("steps")
   validate = operation_steps.find { |step| step.fetch("name") == "Validate operation configuration" }
   raise "operation current-main guard" unless validate.fetch("run").include?("git/ref/heads/main")
+  checkout = operation_steps.find { |step| step.fetch("name") == "Checkout trusted operations automation" }
+  raise "operation checkout action" unless checkout.fetch("uses") == "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
+  raise "operation checkout ref" unless checkout.fetch("with").fetch("ref") == "${{ github.sha }}"
+  raise "operation checkout depth" unless checkout.fetch("with").fetch("fetch-depth") == 1
+  raise "operation checkout credentials" unless checkout.fetch("with").fetch("persist-credentials") == false
+  operation_names = operation_steps.map { |step| step.fetch("name") }
+  auth = operation_steps.find { |step| step.fetch("name") == "Google Auth" }
+  raise "operation checkout order" unless operation_names.index(validate.fetch("name")) < operation_names.index(checkout.fetch("name")) && operation_names.index(checkout.fetch("name")) < operation_names.index(auth.fetch("name"))
 ' "${repo_root}/.github/workflows/ci.yml" "${workflow}" "${repo_root}/deploy/cloud-run/jobs/device-cleanup.yaml" "${operations_workflow}"
 
 printf 'release checks: PASS\n'

--- a/.github/scripts/release/release_test.sh
+++ b/.github/scripts/release/release_test.sh
@@ -130,6 +130,19 @@ state "${parent}" '' '' true false true
 preflight >/dev/null 2>&1 && fail baseline-with-missing
 state "${future}" "${future}" "${future}" true true true
 preflight >/dev/null 2>&1 && fail rollback
+state "${future}" "${future}" "${future}" true true true
+pinned_rollback_output="${temp_dir}/pinned-rollback-preflight.txt"
+if ! (
+  cd "${git_dir}"
+  RELEASE_SHA="${sha}" REQUESTED_SHA="${sha}" CONTROL_SHA="${future}" BUNDLE_FILE="${bundle}" RELEASE_STATE_FILE="${temp_dir}/state.json" \
+    REGISTRY="${TEST_REGISTRY:-registry.example}" OWNER=repo \
+    RELEASE_BASELINE_DIGESTS_FILE="${baseline_map}" ALLOW_RELEASE_FIXTURES=true \
+    bash "${script_dir}/release.sh" preflight
+) >"${pinned_rollback_output}" 2>&1; then
+  fail pinned-rollback-preflight
+fi
+[ "$(jq -r .baseline_sha "${pinned_rollback_output}")" = "${future}" ] \
+  || fail pinned-rollback-baseline
 state broken broken broken true true true
 preflight >/dev/null 2>&1 && fail malformed-label
 state "${parent}" "${parent}" "${sha}" true true true
@@ -354,6 +367,13 @@ if [ "${MOCK_INVALID_DIGEST:-false}" = true ]; then
   printf 'registry.example/repo/radar:latest\n'
   exit 0
 fi
+if [ -n "${MOCK_MISSING_IMAGE_TARGET:-}" ]; then
+  case "$*" in
+    *"artifacts docker images describe registry.example/repo/${MOCK_MISSING_IMAGE_TARGET}:${MOCK_CANDIDATE_SHA}"*)
+      printf 'ERROR: (gcloud.artifacts.docker.images.describe) NOT_FOUND: requested image was not found.\n' >&2
+      exit 1 ;;
+  esac
+fi
 case "$*" in
   *"artifacts docker images describe registry.example/repo/radar:${MOCK_CANDIDATE_SHA}"*)
     printf 'registry.example/repo/radar@sha256:%s\n' "$(printf 'a%.0s' {1..64})" ;;
@@ -369,6 +389,21 @@ cat > "${resolver_bin}/gh" <<'MOCK'
 exit 0
 MOCK
 chmod +x "${resolver_bin}/gcloud" "${resolver_bin}/gh"
+run_resolver() {
+  local control_sha=$1 output_file=$2 requested_sha=${3:-} missing_image_target=${4:-}
+  (
+    cd "${resolver_dir}"
+    PATH="${resolver_bin}:${PATH}" \
+      CONTROL_SHA="${control_sha}" REQUESTED_SHA="${requested_sha}" \
+      DEV_PROJECT_ID=test DEV_REGISTRY=registry.example OWNER=repo \
+      GITHUB_REPOSITORY=repo/test GITHUB_OUTPUT="${output_file}" \
+      RUNNER_TEMP="${resolver_runner}" MOCK_CANDIDATE_SHA="${resolver_candidate}" \
+      MOCK_MISSING_IMAGE_TARGET="${missing_image_target}" \
+      TARGETS_FILE="${repo_root}/.github/scripts/release/targets.json" \
+      IMPACT_PATHS_FILE="${repo_root}/.github/scripts/release/impact-paths.txt" \
+      bash "${script_dir}/release.sh" resolve-candidate
+  )
+}
 resolver_output="${temp_dir}/resolver-output"
 resolver_bundle="${temp_dir}/resolver-bundle.json"
 (
@@ -389,6 +424,22 @@ expected_targets=$(jq -c 'keys | sort' "${repo_root}/.github/scripts/release/tar
 jq -e --arg sha "${resolver_candidate}" --argjson expected "${expected_targets}" \
   '.release_sha == $sha and (.images | keys | sort) == $expected' "${resolver_bundle}" >/dev/null \
   || fail resolver-bundle-content
+resolver_unrelated=$(git -C "${resolver_dir}" commit-tree "$(git -C "${resolver_dir}" rev-parse "${resolver_control}^{tree}")" -m unrelated)
+resolver_pin_non_ancestor_output="${temp_dir}/resolver-pin-non-ancestor-output"
+if run_resolver "${resolver_control}" "${temp_dir}/resolver-pin-non-ancestor-env" "${resolver_unrelated}" \
+  >"${resolver_pin_non_ancestor_output}" 2>&1; then
+  fail resolver-pin-non-ancestor-open
+fi
+grep -F 'not an ancestor' "${resolver_pin_non_ancestor_output}" >/dev/null \
+  || fail resolver-pin-non-ancestor-message
+resolver_pin_incomplete_output="${temp_dir}/resolver-pin-incomplete-output"
+if run_resolver "${resolver_control}" "${temp_dir}/resolver-pin-incomplete-env" "${resolver_candidate}" device-cleanup \
+  >"${resolver_pin_incomplete_output}" 2>&1; then
+  fail resolver-pin-incomplete-open
+fi
+grep -F "pinned candidate ${resolver_candidate} has no complete attested image set" \
+  "${resolver_pin_incomplete_output}" >/dev/null \
+  || fail resolver-pin-incomplete-message
 
 resolver_git_fail_bin="${temp_dir}/resolver-git-fail-bin"
 mkdir -p "${resolver_git_fail_bin}"
@@ -488,6 +539,13 @@ printf 'release-impact\n' > "${resolver_dir}/Dockerfile"
 git -C "${resolver_dir}" add Dockerfile
 git -C "${resolver_dir}" commit -q -m release-impact
 resolver_impact_control=$(git -C "${resolver_dir}" rev-parse HEAD)
+resolver_pinned_output="${temp_dir}/resolver-pinned-output"
+run_resolver "${resolver_impact_control}" "${resolver_pinned_output}" "${resolver_candidate}"
+grep -F "release_sha=${resolver_candidate}" "${resolver_pinned_output}" >/dev/null \
+  || fail resolver-pinned-sha
+resolver_pinned_bundle=$(sed -n 's/^path=//p' "${resolver_pinned_output}")
+jq -e --arg sha "${resolver_candidate}" '.release_sha == $sha' "${resolver_pinned_bundle}" >/dev/null \
+  || fail resolver-pinned-bundle
 if (
   cd "${resolver_dir}"
   PATH="${resolver_bin}:${PATH}" \
@@ -583,14 +641,30 @@ ruby -ryaml -e '
   raise "attestation finalization order" unless publish_names.index(attest.fetch("name")) < publish_names.index(verify.fetch("name")) && publish_names.index(verify.fetch("name")) < publish_names.index(finalize.fetch("name"))
   raise "existing attestation fail-closed" unless verify.fetch("run").include?("Existing SHA tag")
   raise "staging cleanup command" unless finalize.fetch("run").include?("artifacts docker tags delete")
+  workflow_dispatch = release.fetch(true).fetch("workflow_dispatch")
+  release_sha_input = workflow_dispatch.fetch("inputs").fetch("release_sha")
+  raise "release sha input description" unless release_sha_input.fetch("description") == "Pin a specific candidate commit SHA (40 hex). Empty = newest candidate."
+  raise "release sha input required" unless release_sha_input.fetch("required") == false
+  raise "release sha input default" unless release_sha_input.fetch("default") == ""
+  raise "release sha input type" unless release_sha_input.fetch("type") == "string"
+  release_env = release.fetch("jobs").fetch("release").fetch("env")
+  raise "requested sha env" unless release_env.fetch("REQUESTED_SHA") == "${{ inputs.release_sha }}"
   steps = release.fetch("jobs").fetch("release").fetch("steps")
   names = steps.map { |step| step.fetch("name") }
+  raise "release sha inline" if steps.any? { |step| step.fetch("run", "").include?("${{ inputs.release_sha }}") }
   raise "registry auth order" unless names.index("Configure dev Registry auth") < names.index("Resolve and verify candidate digests")
   raise "mutation guard order" unless names.index("Recheck current main before mutation") < names.index("Promote exact digests to prod")
   preflight = steps.find { |step| step.fetch("name") == "Preflight target state" }
   promote = steps.find { |step| step.fetch("name") == "Promote exact digests to prod" }
   raise "preflight unconditional" unless preflight["if"].nil?
   raise "preflight order" unless names.index(preflight.fetch("name")) < names.index(promote.fetch("name"))
+  migrations = steps.find { |step| step.fetch("name") == "Detect migration phases" }
+  raise "migration pin guard" unless migrations.fetch("run").include?("if [ -n \"${REQUESTED_SHA:-}\" ]; then")
+  raise "migration pin outputs" unless migrations.fetch("run").include?("pre=false\\nshared=false\\npost=false\\nany=false")
+  raise "migration pin notice" unless migrations.fetch("run").include?("Pinned release: migrations skipped")
+  summary = steps.find { |step| step.fetch("name") == "Write release summary" }
+  raise "summary candidate mode" unless summary.fetch("run").include?("Candidate mode:")
+  raise "summary migration status" unless summary.fetch("run").include?("Migrations:")
   task = job.fetch("spec").fetch("template").fetch("spec").fetch("template").fetch("spec")
   container = task.fetch("containers").first
   raise "job secret" unless container.fetch("env").any? { |env| env.fetch("name") == "POSTGRES_MASTER_DSN" }

--- a/.github/scripts/release/release_test.sh
+++ b/.github/scripts/release/release_test.sh
@@ -643,7 +643,6 @@ ruby -ryaml -e '
   raise "staging cleanup command" unless finalize.fetch("run").include?("artifacts docker tags delete")
   workflow_dispatch = release.fetch(true).fetch("workflow_dispatch")
   release_sha_input = workflow_dispatch.fetch("inputs").fetch("release_sha")
-  raise "release sha input description" unless release_sha_input.fetch("description") == "Pin a specific candidate commit SHA (40 hex). Empty = newest candidate."
   raise "release sha input required" unless release_sha_input.fetch("required") == false
   raise "release sha input default" unless release_sha_input.fetch("default") == ""
   raise "release sha input type" unless release_sha_input.fetch("type") == "string"
@@ -659,12 +658,7 @@ ruby -ryaml -e '
   raise "preflight unconditional" unless preflight["if"].nil?
   raise "preflight order" unless names.index(preflight.fetch("name")) < names.index(promote.fetch("name"))
   migrations = steps.find { |step| step.fetch("name") == "Detect migration phases" }
-  raise "migration pin guard" unless migrations.fetch("run").include?("if [ -n \"${REQUESTED_SHA:-}\" ]; then")
-  raise "migration pin outputs" unless migrations.fetch("run").include?("pre=false\\nshared=false\\npost=false\\nany=false")
-  raise "migration pin notice" unless migrations.fetch("run").include?("Pinned release: migrations skipped")
-  summary = steps.find { |step| step.fetch("name") == "Write release summary" }
-  raise "summary candidate mode" unless summary.fetch("run").include?("Candidate mode:")
-  raise "summary migration status" unless summary.fetch("run").include?("Migrations:")
+  raise "migration pin guard" unless migrations.fetch("run").include?("REQUESTED_SHA")
   task = job.fetch("spec").fetch("template").fetch("spec").fetch("template").fetch("spec")
   container = task.fetch("containers").first
   raise "job secret" unless container.fetch("env").any? { |env| env.fetch("name") == "POSTGRES_MASTER_DSN" }

--- a/.github/scripts/release/release_test.sh
+++ b/.github/scripts/release/release_test.sh
@@ -793,9 +793,8 @@ ruby -ryaml -e '
   validate = operation_steps.find { |step| step.fetch("name") == "Validate operation configuration" }
   raise "operation current-main guard" unless validate.fetch("run").include?("git/ref/heads/main")
   checkout = operation_steps.find { |step| step.fetch("name") == "Checkout trusted operations automation" }
-  raise "operation checkout action" unless checkout.fetch("uses") == "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
+  raise "operation checkout pinned" unless checkout.fetch("uses") =~ %r{\Aactions/checkout@[0-9a-f]{40}\z}
   raise "operation checkout ref" unless checkout.fetch("with").fetch("ref") == "${{ github.sha }}"
-  raise "operation checkout depth" unless checkout.fetch("with").fetch("fetch-depth") == 1
   raise "operation checkout credentials" unless checkout.fetch("with").fetch("persist-credentials") == false
   operation_names = operation_steps.map { |step| step.fetch("name") }
   auth = operation_steps.find { |step| step.fetch("name") == "Google Auth" }

--- a/.github/scripts/release/release_test.sh
+++ b/.github/scripts/release/release_test.sh
@@ -204,7 +204,26 @@ if [ "${MOCK_REVISION_NOT_FOUND_ONCE:-false}" = true ] \
   && [ "${1:-}" = run ] && [ "${2:-}" = revisions ] && [ "${3:-}" = describe ] \
   && [ "${4:-}" = radar-ready ] && [ ! -e "${MOCK_REVISION_MARKER}" ]; then
   : > "${MOCK_REVISION_MARKER}"
-  printf 'NOT_FOUND\n' >&2
+  printf 'ERROR: (gcloud.run.revisions.describe) Cannot find revision [%s].\n' "${4:-}" >&2
+  exit 1
+fi
+if [ -n "${MOCK_MISSING_TARGET:-}" ] \
+  && [ "${1:-}" = run ] \
+  && { [ "${2:-}" = jobs ] || [ "${2:-}" = services ]; } \
+  && [ "${3:-}" = describe ] \
+  && [ "${4:-}" = "${MOCK_MISSING_TARGET}" ]; then
+  resource_kind=${2%s}
+  printf 'ERROR: (gcloud.run.%s.describe) Cannot find %s [%s].\n' \
+    "${2}" "${resource_kind}" "${4}" >&2
+  exit 1
+fi
+if [ -n "${MOCK_DESCRIBE_ERROR_TARGET:-}" ] \
+  && [ "${1:-}" = run ] \
+  && { [ "${2:-}" = jobs ] || [ "${2:-}" = services ]; } \
+  && [ "${3:-}" = describe ] \
+  && [ "${4:-}" = "${MOCK_DESCRIBE_ERROR_TARGET}" ]; then
+  printf 'ERROR: (gcloud.run.%s.describe) PERMISSION_DENIED: test failure for %s.\n' \
+    "${2}" "${4}" >&2
   exit 1
 fi
 case "$*" in
@@ -227,7 +246,39 @@ esac
 exit 0
 MOCK
 chmod +x "${temp_dir}/bin/kubectl" "${temp_dir}/bin/gcloud"
-common_env=(PATH="${temp_dir}/bin:${PATH}" RELEASE_SHA="${sha}" BUNDLE_FILE="${bundle}" PROJECT_ID=test PROJECT_NUMBER=123456 REGION=region RUNTIME_SA_EMAIL=runtime@example.invalid ALLOWED_HOST=radar.example.invalid GOOGLE_OAUTH_CLIENT_ID=oauth MOCK_JOB_MANIFEST="${temp_dir}/captured-job.yaml" MOCK_MUTATION_MARKER="${temp_dir}/mutation.marker")
+release_functions="${temp_dir}/release-functions.sh"
+sed '/^case "${1:-}" in$/,$d' "${script_dir}/release.sh" > "${release_functions}"
+common_env=(PATH="${temp_dir}/bin:${PATH}" RELEASE_SHA="${sha}" BUNDLE_FILE="${bundle}" PROJECT_ID=test PROJECT_NUMBER=123456 REGION=region REGISTRY=registry.example OWNER=repo RUNTIME_SA_EMAIL=runtime@example.invalid ALLOWED_HOST=radar.example.invalid GOOGLE_OAUTH_CLIENT_ID=oauth MOCK_JOB_MANIFEST="${temp_dir}/captured-job.yaml" MOCK_MUTATION_MARKER="${temp_dir}/mutation.marker")
+assert_missing_cloud_run_target() {
+  local target=$1 snapshot_output preflight_output
+  snapshot_output=$(
+    cd "${git_dir}"
+    env "${common_env[@]}" MOCK_SHA="${sha}" MOCK_RADAR="${digest_a}" MOCK_GEOWORKER="${digest_b}" MOCK_CLEANUP="${digest_c}" \
+      MOCK_MISSING_TARGET="${target}" \
+      bash -c 'source "$1"; snapshot' "${script_dir}/release.sh" "${release_functions}"
+  )
+  jq -e --arg target "${target}" '.[$target].exists == false' <<<"${snapshot_output}" >/dev/null \
+    || fail "${target}-not-found-snapshot"
+  preflight_output="${temp_dir}/${target}-not-found-preflight.txt"
+  if ! env "${common_env[@]}" MOCK_SHA="${sha}" MOCK_RADAR="${digest_a}" MOCK_GEOWORKER="${digest_b}" MOCK_CLEANUP="${digest_c}" \
+    MOCK_MISSING_TARGET="${target}" \
+    bash "${script_dir}/release.sh" preflight >"${preflight_output}" 2>&1; then
+    fail "${target}-not-found-preflight"
+  fi
+}
+assert_missing_cloud_run_target device-cleanup
+assert_missing_cloud_run_target geoworker
+describe_error_output="${temp_dir}/describe-error-preflight.txt"
+if env "${common_env[@]}" MOCK_SHA="${sha}" MOCK_RADAR="${digest_a}" MOCK_GEOWORKER="${digest_b}" MOCK_CLEANUP="${digest_c}" \
+  MOCK_DESCRIBE_ERROR_TARGET=device-cleanup \
+  bash "${script_dir}/release.sh" preflight >"${describe_error_output}" 2>&1; then
+  fail describe-error-preflight-open
+fi
+grep -F 'cannot snapshot device-cleanup' "${describe_error_output}" >/dev/null \
+  || fail describe-error-source-message
+if grep -F 'invalid Cloud Run state' "${describe_error_output}" >/dev/null; then
+  fail describe-error-reached-jq
+fi
 env "${common_env[@]}" TARGET_ENVIRONMENT=dev bash "${script_dir}/release.sh" deploy
 env "${common_env[@]}" TARGET_ENVIRONMENT=prod CLOUDFLARE_ORIGIN_SECRET='safe/+value=' bash "${script_dir}/release.sh" deploy
 [ -s "${temp_dir}/captured-job.yaml" ] || fail job-manifest-capture
@@ -310,7 +361,7 @@ case "$*" in
     printf 'registry.example/repo/geoworker@sha256:%s\n' "$(printf 'b%.0s' {1..64})" ;;
   *"artifacts docker images describe registry.example/repo/device-cleanup:${MOCK_CANDIDATE_SHA}"*)
     printf 'registry.example/repo/device-cleanup@sha256:%s\n' "$(printf 'c%.0s' {1..64})" ;;
-  *) echo 'NOT_FOUND' >&2; exit 1 ;;
+  *) printf 'ERROR: (gcloud.artifacts.docker.images.describe) NOT_FOUND: requested image was not found.\n' >&2; exit 1 ;;
 esac
 MOCK
 cat > "${resolver_bin}/gh" <<'MOCK'

--- a/.github/scripts/release/release_test.sh
+++ b/.github/scripts/release/release_test.sh
@@ -628,6 +628,81 @@ printf '%s\n' "${goose_version}" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$' || fail 
 workflow="${repo_root}/.github/workflows/release-cloud-run.yml"
 ci_workflow="${repo_root}/.github/workflows/ci.yml"
 operations_workflow="${repo_root}/.github/workflows/cloud-run-operations.yml"
+
+# Execute the production promotion step with mocked registry tools so a
+# permission error cannot silently authorize a gcrane copy.
+promote_run="${temp_dir}/promote-run.sh"
+ruby -ryaml -e '
+  workflow = YAML.load_file(ARGV.fetch(0))
+  run = workflow.fetch("jobs").fetch("release").fetch("steps").find { |step| step.fetch("name") == "Promote exact digests to prod" }.fetch("run")
+  print run
+' "${workflow}" > "${promote_run}"
+promote_targets="${temp_dir}/promote-targets.json"
+printf '{"radar":{"kind":"service","overlay":"radar","order":1}}\n' > "${promote_targets}"
+promote_runner="${temp_dir}/promote-runner"
+promote_bin="${temp_dir}/promote-bin"
+mkdir -p "${promote_runner}/gcrane" "${promote_bin}"
+cat > "${promote_bin}/gcloud" <<'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "${1:-}" = auth ]; then
+  exit 0
+fi
+if [ "${1:-}" = artifacts ] && [ "${2:-}" = docker ] && [ "${3:-}" = images ] && [ "${4:-}" = describe ]; then
+  count=0
+  if [ -f "${MOCK_PROMOTE_DESCRIBE_COUNT}" ]; then
+    count=$(<"${MOCK_PROMOTE_DESCRIBE_COUNT}")
+  fi
+  count=$((count + 1))
+  printf '%s\n' "${count}" > "${MOCK_PROMOTE_DESCRIBE_COUNT}"
+  if [ "${count}" -eq 1 ]; then
+    case "${MOCK_PROMOTE_ERROR:-}" in
+      permission)
+        printf 'ERROR: (gcloud.artifacts.docker.images.describe) PERMISSION_DENIED: Could not find valid credentials.\n' >&2
+        exit 1
+        ;;
+      not-found)
+        printf 'ERROR: (gcloud.artifacts.docker.images.describe) NOT_FOUND: requested image was not found.\n' >&2
+        exit 1
+        ;;
+    esac
+  fi
+  printf '%s\n' "${MOCK_PROMOTE_IMAGE}"
+  exit 0
+fi
+printf 'unexpected gcloud invocation: %s\n' "$*" >&2
+exit 1
+MOCK
+cat > "${promote_runner}/gcrane/gcrane" <<'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+: > "${MOCK_PROMOTE_COPY_MARKER}"
+MOCK
+chmod +x "${promote_bin}/gcloud" "${promote_runner}/gcrane/gcrane"
+promote_image="prod.example/repo/radar@sha256:$(printf 'a%.0s' {1..64})"
+run_promote() {
+  local error_mode=$1 copy_marker=$2 describe_count=$3 output_file=$4
+  (
+    cd "${repo_root}"
+    PATH="${promote_bin}:${PATH}" \
+      OWNER=repo DEV_REGISTRY=dev.example REGISTRY=prod.example PROJECT_ID=test \
+      SOURCE_BUNDLE="${bundle}" RELEASE_SHA="${sha}" TARGETS_FILE="${promote_targets}" \
+      RUNNER_TEMP="${promote_runner}" GITHUB_OUTPUT="${output_file}" \
+      MOCK_PROMOTE_ERROR="${error_mode}" MOCK_PROMOTE_COPY_MARKER="${copy_marker}" \
+      MOCK_PROMOTE_DESCRIBE_COUNT="${describe_count}" MOCK_PROMOTE_IMAGE="${promote_image}" \
+      bash "${promote_run}"
+  )
+}
+promote_permission_marker="${temp_dir}/promote-permission-copy.marker"
+if run_promote permission "${promote_permission_marker}" "${temp_dir}/promote-permission-count" "${temp_dir}/promote-permission-output" >/dev/null 2>&1; then
+  fail prod-promote-permission-accepted
+fi
+[ ! -e "${promote_permission_marker}" ] || fail prod-promote-copy-after-permission
+promote_not_found_marker="${temp_dir}/promote-not-found-copy.marker"
+run_promote not-found "${promote_not_found_marker}" "${temp_dir}/promote-not-found-count" "${temp_dir}/promote-not-found-output" >/dev/null 2>&1 \
+  || fail prod-promote-not-found-fallback
+[ -e "${promote_not_found_marker}" ] || fail prod-promote-copy-missing
+
 grep -F 'group: candidate-${{ github.sha }}-${{ matrix.target }}' "${ci_workflow}" >/dev/null || fail matrix-concurrency-scope
 ! grep -F 'verified=false' "${repo_root}/.github/scripts/release/release.sh" >/dev/null || fail attestation-fallback
 grep -F 'has no valid attestation for' "${repo_root}/.github/scripts/release/release.sh" >/dev/null || fail attestation-fail-closed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,7 @@ jobs:
             } >> "${GITHUB_OUTPUT}"
             exit 0
           fi
-          if ! grep -Eiq 'not[[:space:]_-]*found|NOT_FOUND|does not exist|could not find|resource.*missing' "${describe_error}"; then
+          if ! grep -Eiq 'NOT_FOUND|not[[:space:]_-]*found|does not exist|cannot find|could not find|resource.*missing' "${describe_error}"; then
             cat "${describe_error}" >&2
             rm -f "${describe_error}"
             echo "::error::Unable to inspect candidate image for ${TARGET}."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,8 @@ jobs:
         id: stage
         run: |
           set -euo pipefail
+          # shellcheck source=.github/scripts/release/not_found.sh
+          source .github/scripts/release/not_found.sh
           owner=$(printf '%s' "${OWNER}" | tr '[:upper:]' '[:lower:]')
           echo "owner=${owner}" >> "${GITHUB_OUTPUT}"
           built=$(git show -s --format=%cI "${RELEASE_SHA}")
@@ -168,7 +170,7 @@ jobs:
             } >> "${GITHUB_OUTPUT}"
             exit 0
           fi
-          if ! grep -Eiq 'NOT_FOUND|not[[:space:]_-]*found|does not exist|cannot find|could not find|resource.*missing' "${describe_error}"; then
+          if ! not_found_status "${describe_error}"; then
             cat "${describe_error}" >&2
             rm -f "${describe_error}"
             echo "::error::Unable to inspect candidate image for ${TARGET}."

--- a/.github/workflows/cloud-run-operations.yml
+++ b/.github/workflows/cloud-run-operations.yml
@@ -124,6 +124,8 @@ jobs:
           SCHEDULE_TIME_ZONE: ${{ inputs.schedule_time_zone }}
         run: |
           set -euo pipefail
+          # shellcheck source=.github/scripts/release/not_found.sh
+          source .github/scripts/release/not_found.sh
           uri="https://run.googleapis.com/v2/projects/${PROJECT_ID}/locations/${REGION}/jobs/device-cleanup:run"
           common=(
             --project="${PROJECT_ID}"
@@ -143,7 +145,7 @@ jobs:
             --location="${REGION}" >/dev/null 2>"${describe_error}"; then
             gcloud scheduler jobs update http "${SCHEDULER_NAME}" "${common[@]}"
           else
-            if ! grep -Eiq 'NOT_FOUND|not[[:space:]_-]*found|does not exist|cannot find|could not find|resource.*missing' "${describe_error}"; then
+            if ! not_found_status "${describe_error}"; then
               cat "${describe_error}" >&2
               echo "::error::Unable to inspect the fixed Cloud Scheduler job."
               exit 1

--- a/.github/workflows/cloud-run-operations.yml
+++ b/.github/workflows/cloud-run-operations.yml
@@ -143,7 +143,7 @@ jobs:
             --location="${REGION}" >/dev/null 2>"${describe_error}"; then
             gcloud scheduler jobs update http "${SCHEDULER_NAME}" "${common[@]}"
           else
-            if ! grep -Eiq 'not[[:space:]_-]*found|NOT_FOUND|does not exist|could not find|resource.*missing' "${describe_error}"; then
+            if ! grep -Eiq 'NOT_FOUND|not[[:space:]_-]*found|does not exist|cannot find|could not find|resource.*missing' "${describe_error}"; then
               cat "${describe_error}" >&2
               echo "::error::Unable to inspect the fixed Cloud Scheduler job."
               exit 1

--- a/.github/workflows/cloud-run-operations.yml
+++ b/.github/workflows/cloud-run-operations.yml
@@ -95,6 +95,13 @@ jobs:
             fi
           fi
 
+      - name: Checkout trusted operations automation
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
       - name: Google Auth
         if: inputs.operation != 'sync-cloudflare-origin-secret'
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0

--- a/.github/workflows/release-cloud-run.yml
+++ b/.github/workflows/release-cloud-run.yml
@@ -212,6 +212,8 @@ jobs:
           RELEASE_SHA: ${{ steps.candidate.outputs.release_sha }}
         run: |
           set -euo pipefail
+          # shellcheck source=.github/scripts/release/not_found.sh
+          source .github/scripts/release/not_found.sh
           owner=$(printf '%s' "${OWNER}" | tr '[:upper:]' '[:lower:]')
           dev_host=$(printf '%s' "${DEV_REGISTRY}" | cut -d/ -f1)
           prod_host=$(printf '%s' "${REGISTRY}" | cut -d/ -f1)
@@ -230,7 +232,7 @@ jobs:
                 exit 1
               }
             else
-              grep -Eiq 'NOT_FOUND|not[[:space:]_-]*found|does not exist|cannot find|could not find|resource.*missing' "${describe_error}" || {
+              not_found_status "${describe_error}" || {
                 cat "${describe_error}" >&2
                 rm -f "${describe_error}"
                 echo "::error::Unable to inspect prod image: ${target}"

--- a/.github/workflows/release-cloud-run.yml
+++ b/.github/workflows/release-cloud-run.yml
@@ -8,6 +8,11 @@ on:
         required: true
         type: choice
         options: [dev, prod]
+      release_sha:
+        description: "Pin a specific candidate commit SHA (40 hex). Empty = newest candidate."
+        required: false
+        default: ""
+        type: string
 
 env:
   GCRANE_VERSION: v0.21.9
@@ -28,6 +33,7 @@ jobs:
     env:
       CONTROL_SHA: ${{ github.sha }}
       TARGET_ENVIRONMENT: ${{ inputs.environment }}
+      REQUESTED_SHA: ${{ inputs.release_sha }}
       PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
       PROJECT_NUMBER: ${{ vars.GCP_PROJECT_NUMBER }}
       REGION: ${{ vars.GCP_REGION }}
@@ -116,6 +122,11 @@ jobs:
           BASELINE_SHA: ${{ steps.preflight.outputs.baseline_sha }}
         run: |
           set -euo pipefail
+          if [ -n "${REQUESTED_SHA:-}" ]; then
+            printf 'pre=false\nshared=false\npost=false\nany=false\n' >> "${GITHUB_OUTPUT}"
+            echo "::notice::Pinned release: migrations skipped. Handle schema separately."
+            exit 0
+          fi
           changed() {
             if git diff --quiet "${BASELINE_SHA}..${RELEASE_SHA}" -- "$1"; then
               return 1
@@ -293,11 +304,23 @@ jobs:
         env:
           RELEASE_SHA: ${{ steps.candidate.outputs.release_sha }}
           BUNDLE_FILE: ${{ inputs.environment == 'prod' && steps.promote.outputs.path || steps.candidate.outputs.path }}
+          MIGRATIONS_ANY: ${{ steps.migrations.outputs.any }}
         run: |
           {
             echo '## Cloud Run release'
             echo
             echo "Environment: \`${TARGET_ENVIRONMENT}\`"
+            if [ -n "${REQUESTED_SHA:-}" ]; then
+              echo "Candidate mode: pinned (\`${RELEASE_SHA}\`)"
+              echo 'Migrations: skipped (pinned release; handle schema separately)'
+            else
+              echo "Candidate mode: newest compatible ancestor (\`${RELEASE_SHA}\`)"
+              if [ "${MIGRATIONS_ANY}" = true ]; then
+                echo 'Migrations: selected phases executed'
+              else
+                echo 'Migrations: none required'
+              fi
+            fi
             echo "Release SHA: \`${RELEASE_SHA}\`"
             echo '| Target | Image |'
             echo '| --- | --- |'

--- a/.github/workflows/release-cloud-run.yml
+++ b/.github/workflows/release-cloud-run.yml
@@ -219,7 +219,7 @@ jobs:
                 exit 1
               }
             else
-              grep -Eiq 'NOT_FOUND|not found|does not exist' "${describe_error}" || {
+              grep -Eiq 'NOT_FOUND|not[[:space:]_-]*found|does not exist|cannot find|could not find|resource.*missing' "${describe_error}" || {
                 cat "${describe_error}" >&2
                 rm -f "${describe_error}"
                 echo "::error::Unable to inspect prod image: ${target}"

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -89,9 +89,10 @@ label. A normal release requires one valid baseline SHA shared by all three
 resources and ancestral to the selected candidate. A pinned release requires
 the selected SHA to be an ancestor of current `main`; it permits a forward or
 rollback move only when the current baseline and selected SHA are comparable
-ancestors of current `main`. A new environment with no resources bootstraps by
-checking every migration phase. A partial retry is accepted only when labels
-contain that consistent baseline and the current target, or when
+ancestors of current `main`. An unpinned release to a new environment with no
+resources bootstraps by checking every migration phase. Pinned releases skip
+migrations and require separate schema handling. A partial retry is accepted only
+when labels contain that consistent baseline and the current target, or when
 missing/unlabeled resources are paired only with the target.
 
 Divergent history, a third SHA, invalid labels, and label/image drift fail

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -86,16 +86,18 @@ selected immutable `main` candidate. Changed directories run in this order:
 
 `radar`, `geoworker`, and `device-cleanup` use the `release-sha` Cloud Run
 label. A normal release requires one valid baseline SHA shared by all three
-resources and ancestral to the selected candidate. A new environment with no
-resources bootstraps by checking every migration phase. A partial retry is
-accepted only when labels contain that consistent baseline and the current
-target, or when missing/unlabeled resources are paired only with the target.
+resources and ancestral to the selected candidate. A pinned release requires
+the selected SHA to be an ancestor of current `main`; it permits a forward or
+rollback move only when the current baseline and selected SHA are comparable
+ancestors of current `main`. A new environment with no resources bootstraps by
+checking every migration phase. A partial retry is accepted only when labels
+contain that consistent baseline and the current target, or when
+missing/unlabeled resources are paired only with the target.
 
-Rollbacks, divergent history, a third SHA, invalid labels, and label/image
-drift fail closed. Resolve those states through approved break-glass recovery;
-the normal workflow does not infer arbitrary history. Database changes remain
-forward-only, and a same-target retry relies on goose to no-op versions already
-applied.
+Divergent history, a third SHA, invalid labels, and label/image drift fail
+closed. A pinned rollback skips all migration phases and requires schema
+handling separately; database changes remain forward-only. A same-target retry
+relies on goose to no-op versions already applied.
 
 The dedicated GCP Secret Manager secret `postgres-migration-dsn` is required.
 There is no fallback to `postgres-master-dsn`. Supabase migrations must use a
@@ -154,11 +156,14 @@ older candidate in that case.
 
 ### Release Cloud Run
 
-`Release Cloud Run` has one input: `environment`, either `dev` or `prod`. The
-workflow must be dispatched from the current `main` HEAD. It executes only
-current protected automation (`CONTROL_SHA`) and walks first-parent history to
-select the newest ancestor with all three complete, attested candidate images
-(`RELEASE_SHA`).
+`Release Cloud Run` has a required `environment` input, either `dev` or `prod`,
+and an optional `release_sha` input containing a full 40-character commit SHA.
+An empty `release_sha` makes the workflow execute only current protected
+automation (`CONTROL_SHA`) and walk first-parent history to select the newest
+ancestor with all three complete, attested candidate images (`RELEASE_SHA`).
+When `release_sha` is supplied, the resolver selects that SHA directly, still
+requires complete immutable images and valid attestations, and skips the
+impact-path freshness check.
 
 This separation allows a docs-only commit after a verified dev release to
 promote that same candidate without rebuilding it. The resolver rejects any
@@ -179,7 +184,8 @@ remain main-only without a required reviewer.
 A release processes the complete bundle in this order:
 
 1. For prod, verify dev and copy exact digests into the prod registry.
-2. Run required migration phases.
+2. Run required migration phases; pinned releases skip migrations and require
+   separate schema handling.
 3. Deploy `geoworker`, `device-cleanup`, then `radar`.
 4. Verify `release-sha`, exact digest, readiness, and Radar `/health`.
 
@@ -279,6 +285,9 @@ record this rollout before declaring readiness:
   newest compatible ancestor without rebuilding; a release-impacting commit
   without a complete candidate fails closed and is recovered by publishing a
   new candidate.
+- [ ] A pinned release SHA is a current-main ancestor with complete attested
+  images; pinned releases skip migrations and are used for approved rollback
+  or version pinning.
 - [ ] `postgres-migration-dsn` is release-only and verified as the intended
   direct/session-mode port `5432` database.
 - [ ] Prod Cloudflare secrets and identifiers match the deployed origin rule;


### PR DESCRIPTION
## Summary
- Fix Cloud Run first-deploy preflight handling for real gcloud not-found errors.
- Propagate snapshot and resource-resolution failures explicitly.
- Add secure pinned candidate SHA support for rollback deployments.
- Skip migrations for pinned releases and report candidate/migration mode in the summary.
- Reject permission and invalid-location errors as resource absence in image and scheduler fallbacks, including prod promotion.
- Remove brittle release-test assertions and simplify baseline compatibility checks.
- Check out trusted operations automation at `github.sha` before sourcing release helpers.

## Validation
- `bash .github/scripts/release/release_test.sh` — PASS (exit 0)
- Prod promotion behavior test — permission-denied lookup fails without `gcrane copy`; genuine `NOT_FOUND` fallback copies and verifies the digest
- ShellCheck — 9 known diagnostics, unchanged (`SC1007 x3`, `SC2153 x2`, `SC2016 x4`)
- actionlint with ShellCheck — no output
- All five mutation tests remain red
- Operations workflow contract test — trusted checkout is pinned, credentialless, shallow, and ordered before Google Auth

## Deployment note
For the first dev deployment, `device-cleanup` being absent is expected. Confirm the dev database can accept all migration phases before dispatching a new run; do not use Re-run.

## Checklist
- [x] This PR does not add or change PostgreSQL functions; Supabase post-migration hardening review is not applicable.
- [x] This PR does not change extension, PostGIS, or database `search_path` behavior; migration workflow and README review are not applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Releases can target a specific commit using an optional release SHA.
  * Pinned releases validate commit ancestry, skip migration execution, and report pinned mode in workflow summaries.
* **Bug Fixes**
  * Improved detection and reporting of missing images, resources, scheduler jobs, and snapshots.
  * Added safeguards for invalid, incompatible, or divergent release histories.
  * Production image promotion now fails safely when required images or attestations are incomplete.
  * Operations workflows now use the requested trusted revision.
* **Documentation**
  * Updated release policies, retry guidance, readiness criteria, and workflow input documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->