### PR TITLE
fix: handle Artifact Registry image not-found errors

### DIFF
--- a/.github/scripts/release/not_found.sh
+++ b/.github/scripts/release/not_found.sh
@@ -4,3 +4,19 @@
 not_found_status() {
   grep -Eq '(^|[[:space:]])NOT_FOUND([:[:space:]]|$)' "$1"
 }
+
+# Any gcloud status code other than NOT_FOUND is a real error, never a missing
+# resource. Keep this list explicit: an unlisted code degrades to the
+# surface-specific wording check, not to a blanket accept.
+other_gcloud_status() {
+  grep -Eq '(^|[[:space:]])(PERMISSION_DENIED|UNAUTHENTICATED|INVALID_ARGUMENT|FAILED_PRECONDITION|RESOURCE_EXHAUSTED|UNAVAILABLE|INTERNAL|ABORTED|UNKNOWN)([:[:space:]]|$)' "$1"
+}
+
+# Artifact Registry reports a missing image with no status token. Observed
+# 2026-08-17 (ci run 32002042274):
+#   ERROR: (gcloud.artifacts.docker.images.describe) Image not found.
+image_not_found() {
+  not_found_status "$1" && return 0
+  other_gcloud_status "$1" && return 1
+  grep -Fqi 'Image not found.' "$1"
+}

--- a/.github/scripts/release/not_found.sh
+++ b/.github/scripts/release/not_found.sh
@@ -12,11 +12,13 @@ other_gcloud_status() {
   grep -Eq '(^|[[:space:]])(PERMISSION_DENIED|UNAUTHENTICATED|INVALID_ARGUMENT|FAILED_PRECONDITION|RESOURCE_EXHAUSTED|UNAVAILABLE|INTERNAL|ABORTED|UNKNOWN)([:[:space:]]|$)' "$1"
 }
 
-# Artifact Registry reports a missing image with no status token. Observed
-# 2026-08-17 (ci run 32002042274):
+# Artifact Registry reports a missing image with no status token. Its wording
+# carries no resource identity, so only the complete observed error line is
+# trusted; status-qualified variants fail closed. Other not-found renderings
+# must be observed before they are accepted. Observed 2026-08-17 (ci run
+# 32002042274):
 #   ERROR: (gcloud.artifacts.docker.images.describe) Image not found.
 image_not_found() {
   not_found_status "$1" && return 0
-  other_gcloud_status "$1" && return 1
-  grep -Fqi 'Image not found.' "$1"
+  grep -Eq '^ERROR: \(gcloud\.artifacts\.docker\.images\.describe\) Image not found\.$' "$1"
 }

--- a/.github/scripts/release/release.sh
+++ b/.github/scripts/release/release.sh
@@ -124,7 +124,7 @@ resolve_candidate_image() {
     --project="${DEV_PROJECT_ID}" --format='value(image_summary.fully_qualified_digest)' 2>"${error_file}"); then
     rm -f "${error_file}"
   else
-    if not_found_status "${error_file}"; then
+    if image_not_found "${error_file}"; then
       rm -f "${error_file}"
       return 1
     fi
@@ -226,8 +226,7 @@ not_found() {
   not_found_status "$3" && return 0
   # Cloud Run renders not-found without a status token. Explicitly reject
   # other gcloud status codes before accepting its resource-specific wording.
-  grep -Eq '(^|[[:space:]])(PERMISSION_DENIED|UNAUTHENTICATED|INVALID_ARGUMENT|FAILED_PRECONDITION|RESOURCE_EXHAUSTED|UNAVAILABLE|INTERNAL|ABORTED|UNKNOWN)([:[:space:]]|$)' "$3" \
-    && return 1
+  other_gcloud_status "$3" && return 1
   grep -Fqi "Cannot find $1 [$2]" "$3"
 }
 

--- a/.github/scripts/release/release_test.sh
+++ b/.github/scripts/release/release_test.sh
@@ -23,6 +23,31 @@ if not_found_status "${status_fixture}"; then
   fail invalid-argument-not-not-found
 fi
 
+image_fixture="${temp_dir}/image-not-found.txt"
+# Command: gcloud artifacts docker images describe <image-ref>
+# Source: Go CI run 32002042274, observed 2026-08-17.
+printf 'ERROR: (gcloud.artifacts.docker.images.describe) Image not found.\n' > "${image_fixture}"
+image_not_found "${image_fixture}" || fail image-not-found-real-ar
+
+# Command: gcloud artifacts docker images describe <image-ref>
+# Source: synthetic NOT_FOUND status-contract fixture; no production capture claimed.
+printf 'ERROR: (gcloud.artifacts.docker.images.describe) NOT_FOUND: requested image was not found.\n' > "${image_fixture}"
+image_not_found "${image_fixture}" || fail image-not-found-status
+
+# Command: gcloud artifacts docker images describe <image-ref>
+# Source: synthetic status-collision fixture; no production capture claimed.
+printf 'ERROR: (gcloud.artifacts.docker.images.describe) PERMISSION_DENIED: Image not found.\n' > "${image_fixture}"
+if image_not_found "${image_fixture}"; then
+  fail image-not-found-permission-collision
+fi
+
+# Command: gcloud artifacts docker images describe <image-ref>
+# Source: synthetic permission-error fixture; no production capture claimed.
+printf 'ERROR: (gcloud.artifacts.docker.images.describe) PERMISSION_DENIED: Could not find valid credentials.\n' > "${image_fixture}"
+if image_not_found "${image_fixture}"; then
+  fail image-not-found-permission-error
+fi
+
 git_dir="${temp_dir}/git"
 git init -q "${git_dir}"
 git -C "${git_dir}" config user.email test@example.invalid
@@ -406,7 +431,7 @@ fi
 if [ -n "${MOCK_MISSING_IMAGE_TARGET:-}" ]; then
   case "$*" in
     *"artifacts docker images describe registry.example/repo/${MOCK_MISSING_IMAGE_TARGET}:${MOCK_CANDIDATE_SHA}"*)
-      printf 'ERROR: (gcloud.artifacts.docker.images.describe) NOT_FOUND: requested image was not found.\n' >&2
+      printf 'ERROR: (gcloud.artifacts.docker.images.describe) Image not found.\n' >&2
       exit 1 ;;
   esac
 fi
@@ -417,7 +442,7 @@ case "$*" in
     printf 'registry.example/repo/geoworker@sha256:%s\n' "$(printf 'b%.0s' {1..64})" ;;
   *"artifacts docker images describe registry.example/repo/device-cleanup:${MOCK_CANDIDATE_SHA}"*)
     printf 'registry.example/repo/device-cleanup@sha256:%s\n' "$(printf 'c%.0s' {1..64})" ;;
-  *) printf 'ERROR: (gcloud.artifacts.docker.images.describe) NOT_FOUND: requested image was not found.\n' >&2; exit 1 ;;
+  *) printf 'ERROR: (gcloud.artifacts.docker.images.describe) Image not found.\n' >&2; exit 1 ;;
 esac
 MOCK
 cat > "${resolver_bin}/gh" <<'MOCK'
@@ -683,7 +708,7 @@ if [ "${1:-}" = artifacts ] && [ "${2:-}" = docker ] && [ "${3:-}" = images ] &&
         exit 1
         ;;
       not-found)
-        printf 'ERROR: (gcloud.artifacts.docker.images.describe) NOT_FOUND: requested image was not found.\n' >&2
+        printf 'ERROR: (gcloud.artifacts.docker.images.describe) Image not found.\n' >&2
         exit 1
         ;;
     esac

--- a/.github/scripts/release/release_test.sh
+++ b/.github/scripts/release/release_test.sh
@@ -48,6 +48,13 @@ if image_not_found "${image_fixture}"; then
   fail image-not-found-permission-error
 fi
 
+# Command: gcloud artifacts docker images describe <image-ref>
+# Source: synthetic unlisted-status fixture; no production capture claimed.
+printf 'ERROR: (gcloud.artifacts.docker.images.describe) DEADLINE_EXCEEDED: Image not found.\n' > "${image_fixture}"
+if image_not_found "${image_fixture}"; then
+  fail image-not-found-unlisted-status
+fi
+
 git_dir="${temp_dir}/git"
 git init -q "${git_dir}"
 git -C "${git_dir}" config user.email test@example.invalid

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
             } >> "${GITHUB_OUTPUT}"
             exit 0
           fi
-          if ! not_found_status "${describe_error}"; then
+          if ! image_not_found "${describe_error}"; then
             cat "${describe_error}" >&2
             rm -f "${describe_error}"
             echo "::error::Unable to inspect candidate image for ${TARGET}."

--- a/.github/workflows/release-cloud-run.yml
+++ b/.github/workflows/release-cloud-run.yml
@@ -232,7 +232,7 @@ jobs:
                 exit 1
               }
             else
-              not_found_status "${describe_error}" || {
+              image_not_found "${describe_error}" || {
                 cat "${describe_error}" >&2
                 rm -f "${describe_error}"
                 echo "::error::Unable to inspect prod image: ${target}"


### PR DESCRIPTION
## Summary

- Accept Artifact Registry's observed `Image not found.` response without weakening `not_found_status`.
- Reuse the explicit gcloud status deny-list for Cloud Run and keep all other failures fail closed.
- Update AR fixtures and add status/collision regression coverage.

## Validation

- Old token-only implementation with the three real AR fixtures: exit 3, `unable to inspect candidate image geoworker`.
- `bash .github/scripts/release/release_test.sh`: PASS, exit 0.
- ShellCheck 0.11.0: 9 known findings (SC1007 x3, SC2153 x2, SC2016 x4).
- actionlint: no output, exit 0.
- Corrected mutation A: exit 1, `FAIL: image-not-found-real-ar`.
- Mutation B: exit 1, `FAIL: permission-error-not-not-found`.

## Scope note

`cloud-run-operations.yml` is unchanged. Cloud Scheduler wording remains pending real-world confirmation; the workflow has no observed run yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release and deployment handling for missing container images.
  * Prevented permission, authentication, and other cloud service errors from being misidentified as missing images.
  * Added support for Artifact Registry’s standard “Image not found” response.
  * Updated validation coverage for image resolution, staging, and promotion scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->