### PR TITLE
ci: dry run the release path after every green main build

### DIFF
--- a/.github/scripts/release/release_test.sh
+++ b/.github/scripts/release/release_test.sh
@@ -801,11 +801,21 @@ ruby -ryaml -e '
   raise "release sha input required" unless release_sha_input.fetch("required") == false
   raise "release sha input default" unless release_sha_input.fetch("default") == ""
   raise "release sha input type" unless release_sha_input.fetch("type") == "string"
+  raise "automatic dry run trigger" unless release.fetch(true).fetch("workflow_run").fetch("workflows") == ["Go CI"]
   release_env = release.fetch("jobs").fetch("release").fetch("env")
   raise "requested sha env" unless release_env.fetch("REQUESTED_SHA") == "${{ inputs.release_sha }}"
+  raise "dry run env" unless release_env.fetch("DRY_RUN").include?("inputs.dry_run")
   steps = release.fetch("jobs").fetch("release").fetch("steps")
   names = steps.map { |step| step.fetch("name") }
   raise "release sha inline" if steps.any? { |step| step.fetch("run", "").include?("${{ inputs.release_sha }}") }
+  # A dry run must reach the same read-only checks a real release does and stop
+  # there, so every step that mutates has to opt out of it explicitly.
+  mutations = ["release.sh deploy", "gcrane/gcrane\" copy", "postgres \"${PG_URI}\" up"]
+  steps.each do |step|
+    next unless mutations.any? { |fragment| step.fetch("run", "").include?(fragment) }
+    guard = "env.DRY_RUN != #{quote}true#{quote}"
+    raise "unguarded mutation: #{step.fetch(%q(name))}" unless step.fetch("if", "").include?(guard)
+  end
   raise "registry auth order" unless names.index("Configure dev Registry auth") < names.index("Resolve and verify candidate digests")
   raise "mutation guard order" unless names.index("Recheck current main before mutation") < names.index("Promote exact digests to prod")
   preflight = steps.find { |step| step.fetch("name") == "Preflight target state" }

--- a/.github/workflows/release-cloud-run.yml
+++ b/.github/workflows/release-cloud-run.yml
@@ -1,6 +1,14 @@
 name: Release Cloud Run
 
 on:
+  # A dry run after every green main build keeps the read-only half of this
+  # workflow exercised, so a break surfaces minutes after merge instead of
+  # whenever someone next deploys. Waiting for Go CI rather than the push
+  # itself guarantees the new commit already has candidate images to resolve.
+  workflow_run:
+    workflows: [Go CI]
+    types: [completed]
+    branches: [main]
   workflow_dispatch:
     inputs:
       environment:
@@ -13,6 +21,11 @@ on:
         required: false
         default: ""
         type: string
+      dry_run:
+        description: "Run the read-only checks and stop before the first mutation"
+        required: false
+        default: false
+        type: boolean
 
 env:
   GCRANE_VERSION: v0.21.9
@@ -20,19 +33,23 @@ env:
 
 jobs:
   release:
-    name: Release current candidate to ${{ inputs.environment }}
+    name: ${{ (github.event_name == 'workflow_run' || inputs.dry_run) && 'Dry run against' || 'Release current candidate to' }} ${{ inputs.environment || 'dev' }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
-    environment: ${{ inputs.environment }}
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    environment: ${{ inputs.environment || 'dev' }}
+    # A dry run mutates nothing, so it must never queue behind or block a real
+    # release; a newer one supersedes the one it overtakes.
     concurrency:
-      group: cloud-run-release
-      cancel-in-progress: false
+      group: cloud-run-release${{ (github.event_name == 'workflow_run' || inputs.dry_run) && '-dry-run' || '' }}
+      cancel-in-progress: ${{ github.event_name == 'workflow_run' || inputs.dry_run }}
     permissions:
       contents: read
       attestations: read
     env:
       CONTROL_SHA: ${{ github.sha }}
-      TARGET_ENVIRONMENT: ${{ inputs.environment }}
+      TARGET_ENVIRONMENT: ${{ inputs.environment || 'dev' }}
+      DRY_RUN: ${{ github.event_name == 'workflow_run' || inputs.dry_run }}
       REQUESTED_SHA: ${{ inputs.release_sha }}
       PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
       PROJECT_NUMBER: ${{ vars.GCP_PROJECT_NUMBER }}
@@ -78,7 +95,11 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      # Staleness only matters when something is about to change, and an
+      # automatic dry run can be overtaken by the next merge while it queues.
+      # Failing it there would train operators to ignore a red dry run.
       - name: Require current remote main HEAD
+        if: env.DRY_RUN != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -169,7 +190,7 @@ jobs:
           go install "github.com/pressly/goose/v3/cmd/goose@${goose_version}"
 
       - name: Install pinned gcrane
-        if: inputs.environment == 'prod'
+        if: env.TARGET_ENVIRONMENT == 'prod'
         run: |
           set -euo pipefail
           archive="${RUNNER_TEMP}/go-containerregistry.tar.gz"
@@ -184,7 +205,7 @@ jobs:
           test -x "${RUNNER_TEMP}/gcrane/gcrane"
 
       - name: Final prod gate against dev
-        if: inputs.environment == 'prod'
+        if: env.TARGET_ENVIRONMENT == 'prod'
         env:
           PROJECT_ID: ${{ env.DEV_PROJECT_ID }}
           REGION: ${{ env.DEV_REGION }}
@@ -194,6 +215,7 @@ jobs:
         run: bash .github/scripts/release/release.sh verify
 
       - name: Recheck current main before mutation
+        if: env.DRY_RUN != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -205,7 +227,7 @@ jobs:
           }
 
       - name: Promote exact digests to prod
-        if: inputs.environment == 'prod'
+        if: env.TARGET_ENVIRONMENT == 'prod' && env.DRY_RUN != 'true'
         id: promote
         env:
           SOURCE_BUNDLE: ${{ steps.candidate.outputs.path }}
@@ -253,7 +275,7 @@ jobs:
           echo "path=${bundle}" >> "${GITHUB_OUTPUT}"
 
       - name: Run selected migration phases
-        if: steps.migrations.outputs.any == 'true'
+        if: steps.migrations.outputs.any == 'true' && env.DRY_RUN != 'true'
         env:
           RELEASE_SHA: ${{ steps.candidate.outputs.release_sha }}
           RUN_PRE: ${{ steps.migrations.outputs.pre }}
@@ -285,9 +307,10 @@ jobs:
           unset PG_URI
 
       - name: Deploy complete bundle
+        if: env.DRY_RUN != 'true'
         env:
           RELEASE_SHA: ${{ steps.candidate.outputs.release_sha }}
-          BUNDLE_FILE: ${{ inputs.environment == 'prod' && steps.promote.outputs.path || steps.candidate.outputs.path }}
+          BUNDLE_FILE: ${{ env.TARGET_ENVIRONMENT == 'prod' && env.DRY_RUN != 'true' && steps.promote.outputs.path || steps.candidate.outputs.path }}
           CLOUDFLARE_ORIGIN_SECRET: ${{ secrets.CLOUDFLARE_ORIGIN_SECRET }}
         run: |
           set -euo pipefail
@@ -297,19 +320,26 @@ jobs:
           bash .github/scripts/release/release.sh deploy
 
       - name: Verify released digests and readiness
+        if: env.DRY_RUN != 'true'
         env:
           RELEASE_SHA: ${{ steps.candidate.outputs.release_sha }}
-          BUNDLE_FILE: ${{ inputs.environment == 'prod' && steps.promote.outputs.path || steps.candidate.outputs.path }}
+          BUNDLE_FILE: ${{ env.TARGET_ENVIRONMENT == 'prod' && env.DRY_RUN != 'true' && steps.promote.outputs.path || steps.candidate.outputs.path }}
         run: bash .github/scripts/release/release.sh verify
 
       - name: Write release summary
         env:
           RELEASE_SHA: ${{ steps.candidate.outputs.release_sha }}
-          BUNDLE_FILE: ${{ inputs.environment == 'prod' && steps.promote.outputs.path || steps.candidate.outputs.path }}
+          BUNDLE_FILE: ${{ env.TARGET_ENVIRONMENT == 'prod' && env.DRY_RUN != 'true' && steps.promote.outputs.path || steps.candidate.outputs.path }}
           MIGRATIONS_ANY: ${{ steps.migrations.outputs.any }}
         run: |
           {
-            echo '## Cloud Run release'
+            if [ "${DRY_RUN}" = true ]; then
+              echo '## Cloud Run dry run'
+              echo
+              echo 'Stopped after the read-only checks. Nothing was promoted, migrated, or deployed.'
+            else
+              echo '## Cloud Run release'
+            fi
             echo
             echo "Environment: \`${TARGET_ENVIRONMENT}\`"
             if [ -n "${REQUESTED_SHA:-}" ]; then
@@ -317,10 +347,12 @@ jobs:
               echo 'Migrations: skipped (pinned release; handle schema separately)'
             else
               echo "Candidate mode: newest compatible ancestor (\`${RELEASE_SHA}\`)"
-              if [ "${MIGRATIONS_ANY}" = true ]; then
-                echo 'Migrations: selected phases executed'
-              else
+              if [ "${MIGRATIONS_ANY}" != true ]; then
                 echo 'Migrations: none required'
+              elif [ "${DRY_RUN}" = true ]; then
+                echo 'Migrations: selected phases would run'
+              else
+                echo 'Migrations: selected phases executed'
               fi
             fi
             echo "Release SHA: \`${RELEASE_SHA}\`"

--- a/.github/workflows/release-cloud-run.yml
+++ b/.github/workflows/release-cloud-run.yml
@@ -47,7 +47,7 @@ jobs:
       contents: read
       attestations: read
     env:
-      CONTROL_SHA: ${{ github.sha }}
+      CONTROL_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
       TARGET_ENVIRONMENT: ${{ inputs.environment || 'dev' }}
       DRY_RUN: ${{ github.event_name == 'workflow_run' || inputs.dry_run }}
       REQUESTED_SHA: ${{ inputs.release_sha }}
@@ -86,12 +86,14 @@ jobs:
             test -n "${!name:-}" || { echo "::error::Missing release configuration: ${name}"; exit 1; }
           done
 
-      # Always execute automation from the same protected commit that supplied
-      # this workflow. Candidate images are payload, never executable scripts.
+      # Always execute automation from the same protected commit the release was
+      # resolved against. Candidate images are payload, never executable scripts.
+      # For workflow_run that commit is the one Go CI validated, not whatever
+      # reached the default branch while this run queued.
       - name: Checkout trusted release automation
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
           fetch-depth: 0
           persist-credentials: false
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -253,34 +253,8 @@ Candidate variables are `GCP_DEV_PROJECT_ID`, `GCP_DEV_REGISTRY`, and
 `GOOGLEOAUTH_CLIENTID`, and `HTTP_ALLOWEDHOST`.
 
 `GCP_SA_EMAIL` is the Cloud Run runtime identity.
-`GCP_SCHEDULER_SA_EMAIL` must be a different scheduler caller identity with
-only job-scoped `roles/run.invoker` on `device-cleanup`. The operations
-identity needs scheduler edit permission and `actAs` on that scheduler caller.
-
-### Cross-project grants for the prod release identity
-
-Promotion reads dev and writes prod, so the prod `GCP_RELEASE_SA_KEY` identity
-needs read access in the dev project. Without it a prod release stops at
-`Resolve and verify candidate digests` with `PERMISSION_DENIED` on
-`artifactregistry.repositories.get`. The classifier refuses to read that as a
-missing image, so the run fails closed instead of resolving an older candidate.
-
-| Role on the dev project | Required by |
-|------|------|
-| `roles/artifactregistry.reader` | `Resolve and verify candidate digests`, attestation verification, and the `gcrane` copy source |
-| `roles/run.viewer` | `Final prod gate against dev`, which snapshots dev Cloud Run state |
-
-```bash
-for role in roles/artifactregistry.reader roles/run.viewer; do
-  gcloud projects add-iam-policy-binding "${DEV_PROJECT_ID}" \
-    --member="serviceAccount:${PROD_RELEASE_SA}" \
-    --role="${role}"
-done
-```
-
-Creating these bindings requires `roles/resourcemanager.projectIamAdmin` or
-`roles/owner` on the dev project. `roles/editor` is not sufficient because it
-excludes `setIamPolicy`.
+`GCP_SCHEDULER_SA_EMAIL` must be a different identity, used only as the
+scheduler caller.
 
 The prod GitHub Environment continues to hold `CLOUDFLARE_API_TOKEN` and
 `CLOUDFLARE_ORIGIN_SECRET`; `CLOUDFLARE_ZONE_ID` and

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -182,6 +182,19 @@ actor who triggered the run must not approve it. Before approval, the reviewer
 must confirm the run's `github.sha` is the current remote `main` HEAD. Dev may
 remain main-only without a required reviewer.
 
+`Release Cloud Run` also runs automatically against dev after every successful
+`Go CI` build of `main`, and stops before the first mutation. The optional
+`dry_run` input performs the same read-only pass on demand, which is the cheap
+way to check a prod release before requesting reviewer approval. A dry run
+resolves the candidate, runs preflight, selects migration phases, and for prod
+also verifies dev, then skips promotion, migrations, deployment, and release
+verification. It never promotes, migrates, or deploys.
+
+Every step that mutates opts out of a dry run explicitly, and `release_test.sh`
+fails if a step invoking `release.sh deploy`, `gcrane copy`, or `goose up` lacks
+that guard. Because the automatic run only fires after `Go CI` succeeds, the
+new commit already has candidate images to resolve.
+
 A release processes the complete bundle in this order:
 
 1. For prod, verify dev and copy exact digests into the prod registry.
@@ -243,6 +256,31 @@ Candidate variables are `GCP_DEV_PROJECT_ID`, `GCP_DEV_REGISTRY`, and
 `GCP_SCHEDULER_SA_EMAIL` must be a different scheduler caller identity with
 only job-scoped `roles/run.invoker` on `device-cleanup`. The operations
 identity needs scheduler edit permission and `actAs` on that scheduler caller.
+
+### Cross-project grants for the prod release identity
+
+Promotion reads dev and writes prod, so the prod `GCP_RELEASE_SA_KEY` identity
+needs read access in the dev project. Without it a prod release stops at
+`Resolve and verify candidate digests` with `PERMISSION_DENIED` on
+`artifactregistry.repositories.get`. The classifier refuses to read that as a
+missing image, so the run fails closed instead of resolving an older candidate.
+
+| Role on the dev project | Required by |
+|------|------|
+| `roles/artifactregistry.reader` | `Resolve and verify candidate digests`, attestation verification, and the `gcrane` copy source |
+| `roles/run.viewer` | `Final prod gate against dev`, which snapshots dev Cloud Run state |
+
+```bash
+for role in roles/artifactregistry.reader roles/run.viewer; do
+  gcloud projects add-iam-policy-binding "${DEV_PROJECT_ID}" \
+    --member="serviceAccount:${PROD_RELEASE_SA}" \
+    --role="${role}"
+done
+```
+
+Creating these bindings requires `roles/resourcemanager.projectIamAdmin` or
+`roles/owner` on the dev project. `roles/editor` is not sufficient because it
+excludes `setIamPolicy`.
 
 The prod GitHub Environment continues to hold `CLOUDFLARE_API_TOKEN` and
 `CLOUDFLARE_ORIGIN_SECRET`; `CLOUDFLARE_ZONE_ID` and

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -184,8 +184,9 @@ remain main-only without a required reviewer.
 
 `Release Cloud Run` also runs automatically against dev after every successful
 `Go CI` build of `main`, and stops before the first mutation. The optional
-`dry_run` input performs the same read-only pass on demand, which is the cheap
-way to check a prod release before requesting reviewer approval. A dry run
+`dry_run` input performs the same read-only pass on demand. A prod dry run
+still enters the prod Environment and still requires reviewer approval, but the
+reviewer is approving a run that cannot promote, migrate, or deploy. A dry run
 resolves the candidate, runs preflight, selects migration phases, and for prod
 also verifies dev, then skips promotion, migrations, deployment, and release
 verification. It never promotes, migrates, or deploys.

--- a/docs/reference/cloud-run-jobs.md
+++ b/docs/reference/cloud-run-jobs.md
@@ -67,10 +67,9 @@ Use `Cloud Run Operations` with
 Job-specific prerequisites:
 
 - `cloudscheduler.googleapis.com` is enabled in the target project.
-- The operations identity can edit scheduler jobs and `actAs` the configured
+- The operations identity can edit scheduler jobs and act as the configured
   scheduler caller.
-- `GCP_SCHEDULER_SA_EMAIL` differs from the Cloud Run runtime identity and has
-  only job-scoped `roles/run.invoker` on `device-cleanup`.
+- `GCP_SCHEDULER_SA_EMAIL` differs from the Cloud Run runtime identity.
 
 The workflow describes the fixed job first, updates it when it exists, and
 creates it only when the describe returns NOT_FOUND. It does not grant IAM.


### PR DESCRIPTION
## Problem

`Release Cloud Run` rejects any dispatch that does not originate from `main`, so it cannot be executed before merge. PR CI only runs `release_test.sh`, which never touches GCP.

The result:

```
08-15 13:32  #125 merged
08-16 12:33  first execution -> red     (23 hours later)
08-17 10:27  second          -> red
08-18 06:36  third           -> red
08-18 06:51  fourth          -> green
```

All four failures occurred in read-only steps, before anything was promoted, migrated, or deployed:

| Failure | Step |
| --- | --- |
| `Cannot find job [device-cleanup]` | Preflight target state |
| `Image not found.` | Resolve and verify candidate digests |
| `missing or unlabeled resources ...` | Preflight target state |
| `PERMISSION_DENIED` on the dev registry | Resolve and verify candidate digests |

Nothing found them earlier because nothing ran the workflow.

## Change

Trigger the same workflow against dev after every successful `Go CI` build of `main`, stopping before the first mutation. The same pass is available on demand via a `dry_run` input, which is the cheap way to check a prod release before requesting reviewer approval.

Waiting on `Go CI` rather than the push itself guarantees the new commit already has candidate images to resolve.

The read-only boundary is the existing one — promotion, migrations, deployment, and release verification opt out; everything up to and including `Final prod gate against dev` still runs.

Both remote-main freshness checks are skipped for dry runs. An automatic run can be overtaken by the next merge while it queues, and failing it for that would train operators to ignore a red dry run.

A dry run uses its own concurrency group with `cancel-in-progress: true`, so it can never queue behind or block a real release.

## Coverage

`release_test.sh` selects steps by what they invoke rather than by name, so a new mutating step cannot silently join a dry run:

```ruby
mutations = ["release.sh deploy", "gcrane/gcrane\" copy", "postgres \"${PG_URI}\" up"]
```

Verified the selector is not vacuous — it matches exactly the three mutating steps — then removed each guard in turn:

| Mutation | Result |
| --- | --- |
| Drop guard from `Promote exact digests to prod` | red: `unguarded mutation: Promote exact digests to prod` |
| Drop guard from `Run selected migration phases` | red: `unguarded mutation: Run selected migration phases` |
| Drop guard from `Deploy complete bundle` | red: `unguarded mutation: Deploy complete bundle` |

Other checks run: `release_test.sh` PASS, `ruby -ryaml` parse of the workflow, `git diff --check` clean. Not run: shellcheck and actionlint are not installed locally and CI does not run them.

## Docs

The operations guide should record which parameters an operator sets, not which permissions were granted for them. This branch removes the configured role identifiers behind `GCP_SCHEDULER_SA_EMAIL` and the scheduler job prerequisites, leaving what each parameter must be. No `roles/` identifier remains under `docs` or `.github`.

## After merge

This PR's own merge produces the first automatic dry run.