### PR TITLE
fix: enforce public merchant menu visibility

### DIFF
--- a/internal/usecase/impl/menu_service.go
+++ b/internal/usecase/impl/menu_service.go
@@ -268,7 +268,7 @@ func (s *menuService) validatePublicMerchant(ctx context.Context, merchantID uui
 		return err
 	}
 
-	if merchant.MerchantProfile == nil {
+	if merchant.MerchantProfile == nil || !merchant.MerchantProfile.IsPublic {
 		return domainerrors.ErrMerchantNotFound
 	}
 

--- a/internal/usecase/impl/menu_service_test.go
+++ b/internal/usecase/impl/menu_service_test.go
@@ -391,7 +391,7 @@ func TestMenuService_GetPublicMerchantMenu_Success(t *testing.T) {
 
 			return &entity.User{
 				ID:              merchantID,
-				MerchantProfile: &entity.MerchantProfile{UserID: merchantID},
+				MerchantProfile: &entity.MerchantProfile{UserID: merchantID, IsPublic: true},
 			}, nil
 		},
 	}
@@ -440,6 +440,15 @@ func TestMenuService_GetPublicMerchantMenu_MerchantNotFound(t *testing.T) {
 			name: "user without merchant profile",
 			buildUser: func(merchantID uuid.UUID) *entity.User {
 				return &entity.User{ID: merchantID}
+			},
+		},
+		{
+			name: "merchant profile is not public",
+			buildUser: func(merchantID uuid.UUID) *entity.User {
+				return &entity.User{
+					ID:              merchantID,
+					MerchantProfile: &entity.MerchantProfile{UserID: merchantID, IsPublic: false},
+				}
 			},
 		},
 	}

--- a/k6/idor.js
+++ b/k6/idor.js
@@ -101,6 +101,20 @@ function assertDenied(res, label, expectedCode) {
   }
 }
 
+function assertNotFound(res, label, expectedCode) {
+  assertStatus(res, 404, label);
+
+  const body = parseJSON(res);
+  const code = body && body.error ? body.error.code : "";
+  const ok = check(body, {
+    [`${label} returns ${expectedCode}`]: () => code === expectedCode,
+  });
+
+  if (!ok) {
+    fail(`${label} returned unexpected error code=${code}`);
+  }
+}
+
 function extractData(res, label) {
   const body = parseJSON(res);
   if (!body || body.data === undefined || body.data === null) {
@@ -139,11 +153,28 @@ function findMerchantByID(items, merchantID, label) {
   fail(`${label} did not contain merchant ${merchantID}`);
 }
 
+function canonicalJSON(value) {
+  if (Array.isArray(value)) {
+    return value.map(canonicalJSON);
+  }
+  if (value && typeof value === "object") {
+    const normalized = {};
+    Object.keys(value)
+      .sort()
+      .forEach((key) => {
+        normalized[key] = canonicalJSON(value[key]);
+      });
+    return normalized;
+  }
+
+  return value;
+}
+
 function assertPublicDataEqual(firstRes, secondRes, label) {
   const firstData = extractData(firstRes, `${label} owner response`);
   const secondData = extractData(secondRes, `${label} other response`);
-  const firstJSON = JSON.stringify(firstData);
-  const secondJSON = JSON.stringify(secondData);
+  const firstJSON = JSON.stringify(canonicalJSON(firstData));
+  const secondJSON = JSON.stringify(canonicalJSON(secondData));
   const ok = check(
     { firstData: firstData, secondData: secondData },
     {
@@ -627,6 +658,22 @@ export default function (setupData) {
     if (!publicMenuCheck) {
       fail("idor public merchant menu did not contain the expected item");
     }
+
+    createMenuItem(merchantB.token, discoveryValues.subcategoryID);
+
+    const privateMenuPath = `${API_PREFIX}/merchants/${merchantB.userID}/menu?page=1&page_size=20`;
+    const otherPrivateMenuRes = request(
+      "GET",
+      privateMenuPath,
+      userA.token,
+      undefined,
+      "idor_other_get_private_merchant_menu",
+    );
+    assertNotFound(
+      otherPrivateMenuRes,
+      "idor other get private merchant menu",
+      "MERCHANT_NOT_FOUND",
+    );
 
     assertDenied(
       request(


### PR DESCRIPTION
## Summary

- Require `MerchantProfile.IsPublic` before serving the consumer-facing merchant menu.
- Return the existing `MERCHANT_NOT_FOUND` error for both missing and private merchants.
- Add unit and k6 coverage for private merchant menu access.
- Make k6 public payload equality independent of JSON object key order.

## Verification

- `go build ./...`
- `go vet ./...`
- `go test ./internal/usecase/...` — 235 passed
- `go test ./...` — 632 passed
- Mutation test: reverting the visibility guard fails `merchant profile is not public` on the menu-repository-not-called assertion.
- `make k6-idor` — 63/63 checks passed, 100% check rate.
- `k6 inspect k6/idor.js`

The private-menu k6 case creates a menu item for an unpublished merchant and verifies a user-role request receives 404 with `MERCHANT_NOT_FOUND`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Public menus are now available only for merchant profiles explicitly marked as public.
  - Non-public or missing merchant profiles return a “merchant not found” result.
  - Invalid merchant requests no longer query menu data unnecessarily.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->