### PR TITLE
feat: rate limit authenticated API by user

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -20,18 +20,21 @@ import (
 )
 
 const (
-	defaultPath                 = "."
-	defaultMaxRequestBodySize   = "100KB"
-	postgresMasterDSNEnvKey     = "POSTGRES_MASTER_DSN"
-	defaultAccessTokenTTL       = 15 * time.Minute
-	defaultRefreshTokenTTL      = 7 * 24 * time.Hour
-	defaultOnboardingTokenTTL   = 10 * time.Minute
-	defaultLinkingTokenTTL      = 10 * time.Minute
-	defaultNotificationTimeout  = 10 * time.Second
-	defaultDeviceCleanupTimeout = 5 * time.Minute
-	defaultRateLimitRate        = 10.0
-	defaultRateLimitBurst       = 30
-	defaultRateLimitExpiresIn   = 3 * time.Minute
+	defaultPath                  = "."
+	defaultMaxRequestBodySize    = "100KB"
+	postgresMasterDSNEnvKey      = "POSTGRES_MASTER_DSN"
+	defaultAccessTokenTTL        = 15 * time.Minute
+	defaultRefreshTokenTTL       = 7 * 24 * time.Hour
+	defaultOnboardingTokenTTL    = 10 * time.Minute
+	defaultLinkingTokenTTL       = 10 * time.Minute
+	defaultNotificationTimeout   = 10 * time.Second
+	defaultDeviceCleanupTimeout  = 5 * time.Minute
+	defaultRateLimitRate         = 10.0
+	defaultRateLimitBurst        = 30
+	defaultRateLimitExpiresIn    = 3 * time.Minute
+	defaultAPIRateLimitRate      = 20.0
+	defaultAPIRateLimitBurst     = 60
+	defaultAPIRateLimitExpiresIn = 3 * time.Minute
 )
 
 type Config struct {
@@ -49,6 +52,7 @@ type Config struct {
 		CloudflareSecret   string           `json:"cloudflareSecret" yaml:"cloudflareSecret"`
 		CORSAllowedOrigins string           `json:"corsAllowedOrigins" yaml:"corsAllowedOrigins"`
 		RateLimit          *RateLimitConfig `json:"rateLimit" yaml:"rateLimit"`
+		APIRateLimit       *RateLimitConfig `json:"apiRateLimit" yaml:"apiRateLimit"`
 		Timeouts           struct {
 			ReadTimeout       time.Duration `json:"readTimeout" yaml:"readTimeout"`
 			ReadHeaderTimeout time.Duration `json:"readHeaderTimeout" yaml:"readHeaderTimeout"`
@@ -124,7 +128,7 @@ type LoginThrottleConfig struct {
 	LockoutDecayDays int `json:"lockoutDecayDays" yaml:"lockoutDecayDays"`
 }
 
-// RateLimitConfig defines the in-process rate limiter for authentication routes.
+// RateLimitConfig defines in-process rate limiter settings.
 type RateLimitConfig struct {
 	Enabled   *bool          `json:"enabled" yaml:"enabled"`
 	Rate      *float64       `json:"rate" yaml:"rate"`
@@ -147,12 +151,27 @@ func DefaultRateLimitConfig() RateLimitConfig {
 	}
 }
 
+// DefaultAPIRateLimitConfig returns the default authenticated API rate limit settings.
+func DefaultAPIRateLimitConfig() RateLimitConfig {
+	enabled := true
+	rate := defaultAPIRateLimitRate
+	burst := defaultAPIRateLimitBurst
+	expiresIn := defaultAPIRateLimitExpiresIn
+
+	return RateLimitConfig{
+		Enabled:   &enabled,
+		Rate:      &rate,
+		Burst:     &burst,
+		ExpiresIn: &expiresIn,
+	}
+}
+
 // IsEnabled reports whether the rate limiter is enabled. A missing value defaults to enabled.
 func (cfg RateLimitConfig) IsEnabled() bool {
 	return cfg.Enabled == nil || *cfg.Enabled
 }
 
-// Validate checks the rate limiter values used by the authentication middleware.
+// Validate checks the rate limiter values.
 func (cfg RateLimitConfig) Validate() error {
 	if !cfg.IsEnabled() {
 		return nil
@@ -380,11 +399,20 @@ func ApplyDefaults(cfg *Config) {
 
 // Validate checks configuration values that must be safe before starting a service.
 func (cfg *Config) Validate() error {
-	if cfg == nil || cfg.HTTP.RateLimit == nil {
+	if cfg == nil {
 		return nil
 	}
 
-	return cfg.HTTP.RateLimit.Validate()
+	if cfg.HTTP.RateLimit != nil {
+		if err := cfg.HTTP.RateLimit.Validate(); err != nil {
+			return err
+		}
+	}
+	if cfg.HTTP.APIRateLimit != nil {
+		return cfg.HTTP.APIRateLimit.Validate()
+	}
+
+	return nil
 }
 
 func applyHTTPDefaults(cfg *Config) {
@@ -392,25 +420,28 @@ func applyHTTPDefaults(cfg *Config) {
 		cfg.HTTP.MaxRequestBodySize = defaultMaxRequestBodySize
 	}
 
-	if cfg.HTTP.RateLimit == nil {
-		defaults := DefaultRateLimitConfig()
-		cfg.HTTP.RateLimit = &defaults
+	applyRateLimitDefaults(&cfg.HTTP.RateLimit, DefaultRateLimitConfig())
+	applyRateLimitDefaults(&cfg.HTTP.APIRateLimit, DefaultAPIRateLimitConfig())
+}
+
+func applyRateLimitDefaults(cfg **RateLimitConfig, defaults RateLimitConfig) {
+	if *cfg == nil {
+		*cfg = &defaults
 
 		return
 	}
 
-	defaults := DefaultRateLimitConfig()
-	if cfg.HTTP.RateLimit.Enabled == nil {
-		cfg.HTTP.RateLimit.Enabled = defaults.Enabled
+	if (*cfg).Enabled == nil {
+		(*cfg).Enabled = defaults.Enabled
 	}
-	if cfg.HTTP.RateLimit.Rate == nil {
-		cfg.HTTP.RateLimit.Rate = defaults.Rate
+	if (*cfg).Rate == nil {
+		(*cfg).Rate = defaults.Rate
 	}
-	if cfg.HTTP.RateLimit.Burst == nil {
-		cfg.HTTP.RateLimit.Burst = defaults.Burst
+	if (*cfg).Burst == nil {
+		(*cfg).Burst = defaults.Burst
 	}
-	if cfg.HTTP.RateLimit.ExpiresIn == nil {
-		cfg.HTTP.RateLimit.ExpiresIn = defaults.ExpiresIn
+	if (*cfg).ExpiresIn == nil {
+		(*cfg).ExpiresIn = defaults.ExpiresIn
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -173,29 +173,34 @@ func (cfg RateLimitConfig) IsEnabled() bool {
 
 // Validate checks the rate limiter values.
 func (cfg RateLimitConfig) Validate() error {
+	return cfg.ValidateAt("http.rateLimit")
+}
+
+// ValidateAt checks the rate limiter values and reports errors under path.
+func (cfg RateLimitConfig) ValidateAt(path string) error {
 	if !cfg.IsEnabled() {
 		return nil
 	}
 	if cfg.Rate == nil {
-		return fmt.Errorf("http.rateLimit.rate must be set")
+		return fmt.Errorf("%s.rate must be set", path)
 	}
 	if math.IsNaN(*cfg.Rate) || math.IsInf(*cfg.Rate, 0) {
-		return fmt.Errorf("http.rateLimit.rate must be finite")
+		return fmt.Errorf("%s.rate must be finite", path)
 	}
 	if *cfg.Rate <= 0 {
-		return fmt.Errorf("http.rateLimit.rate must be greater than zero")
+		return fmt.Errorf("%s.rate must be greater than zero", path)
 	}
 	if cfg.Burst == nil {
-		return fmt.Errorf("http.rateLimit.burst must be set")
+		return fmt.Errorf("%s.burst must be set", path)
 	}
 	if *cfg.Burst <= 0 {
-		return fmt.Errorf("http.rateLimit.burst must be greater than zero")
+		return fmt.Errorf("%s.burst must be greater than zero", path)
 	}
 	if cfg.ExpiresIn == nil {
-		return fmt.Errorf("http.rateLimit.expiresIn must be set")
+		return fmt.Errorf("%s.expiresIn must be set", path)
 	}
 	if *cfg.ExpiresIn <= 0 {
-		return fmt.Errorf("http.rateLimit.expiresIn must be greater than zero")
+		return fmt.Errorf("%s.expiresIn must be greater than zero", path)
 	}
 
 	return nil
@@ -409,7 +414,7 @@ func (cfg *Config) Validate() error {
 		}
 	}
 	if cfg.HTTP.APIRateLimit != nil {
-		return cfg.HTTP.APIRateLimit.Validate()
+		return cfg.HTTP.APIRateLimit.ValidateAt("http.apiRateLimit")
 	}
 
 	return nil

--- a/config/rate_limit_test.go
+++ b/config/rate_limit_test.go
@@ -29,6 +29,28 @@ func TestApplyDefaults_RateLimit(t *testing.T) {
 	}
 }
 
+func TestApplyDefaults_APIRateLimit(t *testing.T) {
+	cfg := &Config{}
+
+	ApplyDefaults(cfg)
+
+	if cfg.HTTP.APIRateLimit == nil {
+		t.Fatal("expected API rate limit defaults")
+	}
+	if !cfg.HTTP.APIRateLimit.IsEnabled() {
+		t.Fatal("expected API rate limit to be enabled by default")
+	}
+	if cfg.HTTP.APIRateLimit.Rate == nil || *cfg.HTTP.APIRateLimit.Rate != 20 {
+		t.Fatalf("Rate = %v, want 20", cfg.HTTP.APIRateLimit.Rate)
+	}
+	if cfg.HTTP.APIRateLimit.Burst == nil || *cfg.HTTP.APIRateLimit.Burst != 60 {
+		t.Fatalf("Burst = %v, want 60", cfg.HTTP.APIRateLimit.Burst)
+	}
+	if cfg.HTTP.APIRateLimit.ExpiresIn == nil || *cfg.HTTP.APIRateLimit.ExpiresIn != 3*time.Minute {
+		t.Fatalf("ExpiresIn = %v, want 3m", cfg.HTTP.APIRateLimit.ExpiresIn)
+	}
+}
+
 func TestApplyDefaults_RateLimitPreservesDisabledValue(t *testing.T) {
 	enabled := false
 	cfg := &Config{}
@@ -41,6 +63,33 @@ func TestApplyDefaults_RateLimitPreservesDisabledValue(t *testing.T) {
 	}
 	if err := cfg.Validate(); err != nil {
 		t.Fatalf("Validate() error = %v", err)
+	}
+}
+
+func TestApplyDefaults_APIRateLimitPreservesDisabledValue(t *testing.T) {
+	enabled := false
+	cfg := &Config{}
+	cfg.HTTP.APIRateLimit = &RateLimitConfig{Enabled: &enabled}
+
+	ApplyDefaults(cfg)
+
+	if cfg.HTTP.APIRateLimit.IsEnabled() {
+		t.Fatal("expected explicit API rate limit disabled value to be preserved")
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+}
+
+func TestConfigValidateRejectsInvalidAPIRateLimit(t *testing.T) {
+	settings := newRateLimitConfig(0, 1, time.Minute)
+	cfg := &Config{}
+	cfg.HTTP.APIRateLimit = &settings
+
+	ApplyDefaults(cfg)
+
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("Validate() expected an error for invalid API rate-limit values")
 	}
 }
 

--- a/config/rate_limit_test.go
+++ b/config/rate_limit_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"math"
 	"os"
+	"strings"
 	"testing"
 	"time"
 )
@@ -88,8 +89,26 @@ func TestConfigValidateRejectsInvalidAPIRateLimit(t *testing.T) {
 
 	ApplyDefaults(cfg)
 
-	if err := cfg.Validate(); err == nil {
+	err := cfg.Validate()
+	if err == nil {
 		t.Fatal("Validate() expected an error for invalid API rate-limit values")
+	}
+	if !strings.Contains(err.Error(), "http.apiRateLimit.rate") {
+		t.Fatalf("Validate() error = %v, want API rate-limit path", err)
+	}
+}
+
+func TestRateLimitConfigValidateUsesDefaultAndExplicitPaths(t *testing.T) {
+	settings := newRateLimitConfig(0, 1, time.Minute)
+
+	err := settings.Validate()
+	if err == nil || !strings.Contains(err.Error(), "http.rateLimit.rate") {
+		t.Fatalf("Validate() error = %v, want authentication rate-limit path", err)
+	}
+
+	err = settings.ValidateAt("http.apiRateLimit")
+	if err == nil || !strings.Contains(err.Error(), "http.apiRateLimit.rate") {
+		t.Fatalf("ValidateAt() error = %v, want API rate-limit path", err)
 	}
 }
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -259,6 +259,14 @@ header; direct environments ignore forwarded IP headers and use the network
 peer address. This application-layer limiter does not replace a Cloudflare-wide
 rate-limiting rule.
 
+Authenticated `/api/v1/*` endpoints use a separate in-process Echo rate limiter
+keyed by the authenticated user ID. Its defaults are 20 requests/second, a
+burst of 60, and three-minute visitor cleanup. If the authentication context is
+missing, the middleware defensively falls back to the client IP. The limiter is
+local to each Cloud Run instance and does not replace a Cloudflare-wide
+rate-limiting rule. Its defaults are used when no API-specific configuration is
+provided; this phase does not add separate environment-variable overrides.
+
 `GCP_SA_EMAIL` is the Cloud Run runtime identity.
 `GCP_SCHEDULER_SA_EMAIL` must be a different identity, and its permission to
 invoke Cloud Run must be limited to `device-cleanup` alone. Nothing in this

--- a/internal/delivery/api/middleware/rate_limit.go
+++ b/internal/delivery/api/middleware/rate_limit.go
@@ -37,3 +37,35 @@ func NewAuthRateLimiter(cfg *config.Config) (echo.MiddlewareFunc, error) {
 		},
 	}), nil
 }
+
+// NewAPIRateLimiter creates the in-process limiter shared by authenticated API routes.
+// It keys requests by authenticated user ID and falls back to the client IP when no user is present.
+func NewAPIRateLimiter(cfg *config.Config) (echo.MiddlewareFunc, error) {
+	settings := config.DefaultAPIRateLimitConfig()
+	if cfg != nil && cfg.HTTP.APIRateLimit != nil {
+		settings = *cfg.HTTP.APIRateLimit
+	}
+	if err := settings.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid API rate limit configuration: %w", err)
+	}
+	if !settings.IsEnabled() {
+		return nil, nil
+	}
+
+	store := echomiddleware.NewRateLimiterMemoryStoreWithConfig(echomiddleware.RateLimiterMemoryStoreConfig{
+		Rate:      rate.Limit(*settings.Rate),
+		Burst:     *settings.Burst,
+		ExpiresIn: *settings.ExpiresIn,
+	})
+
+	return echomiddleware.RateLimiterWithConfig(echomiddleware.RateLimiterConfig{
+		Store: store,
+		IdentifierExtractor: func(c echo.Context) (string, error) {
+			if userID, ok := GetUserID(c); ok {
+				return userID.String(), nil
+			}
+
+			return c.RealIP(), nil
+		},
+	}), nil
+}

--- a/internal/delivery/api/middleware/rate_limit.go
+++ b/internal/delivery/api/middleware/rate_limit.go
@@ -45,7 +45,7 @@ func NewAPIRateLimiter(cfg *config.Config) (echo.MiddlewareFunc, error) {
 	if cfg != nil && cfg.HTTP.APIRateLimit != nil {
 		settings = *cfg.HTTP.APIRateLimit
 	}
-	if err := settings.Validate(); err != nil {
+	if err := settings.ValidateAt("http.apiRateLimit"); err != nil {
 		return nil, fmt.Errorf("invalid API rate limit configuration: %w", err)
 	}
 	if !settings.IsEnabled() {

--- a/internal/delivery/api/middleware/rate_limit_test.go
+++ b/internal/delivery/api/middleware/rate_limit_test.go
@@ -9,6 +9,7 @@ import (
 
 	"radar/config"
 
+	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -67,6 +68,107 @@ func TestAuthRateLimiter_RejectsInvalidConfiguration(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestAPIRateLimiter_UsesSeparateBucketPerUser(t *testing.T) {
+	settings := newRateLimitConfig(0.001, 1, time.Minute)
+	cfg := &config.Config{}
+	cfg.HTTP.APIRateLimit = settings
+	limiter, err := NewAPIRateLimiter(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, limiter)
+
+	e := newUserRateLimitEcho(limiter)
+	remoteAddr := "192.0.2.1:1000"
+	userA := uuid.New()
+	userB := uuid.New()
+
+	userARequest := newUserRateLimitRequest("/api/v1/one", remoteAddr, userA)
+	userAResponse := httptest.NewRecorder()
+	e.ServeHTTP(userAResponse, userARequest)
+	assert.Equal(t, http.StatusNoContent, userAResponse.Code)
+
+	userBRequest := newUserRateLimitRequest("/api/v1/one", remoteAddr, userB)
+	userBResponse := httptest.NewRecorder()
+	e.ServeHTTP(userBResponse, userBRequest)
+	assert.Equal(t, http.StatusNoContent, userBResponse.Code)
+
+	secondUserARequest := newUserRateLimitRequest("/api/v1/one", remoteAddr, userA)
+	secondUserAResponse := httptest.NewRecorder()
+	e.ServeHTTP(secondUserAResponse, secondUserARequest)
+	assert.Equal(t, http.StatusTooManyRequests, secondUserAResponse.Code)
+}
+
+func TestAPIRateLimiter_SharesBucketAcrossAPIRoutes(t *testing.T) {
+	settings := newRateLimitConfig(0.001, 1, time.Minute)
+	cfg := &config.Config{}
+	cfg.HTTP.APIRateLimit = settings
+	limiter, err := NewAPIRateLimiter(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, limiter)
+
+	e := newUserRateLimitEcho(limiter)
+	userID := uuid.New()
+	remoteAddr := "192.0.2.1:1000"
+
+	firstRequest := newUserRateLimitRequest("/api/v1/one", remoteAddr, userID)
+	firstResponse := httptest.NewRecorder()
+	e.ServeHTTP(firstResponse, firstRequest)
+	assert.Equal(t, http.StatusNoContent, firstResponse.Code)
+
+	secondRequest := newUserRateLimitRequest("/api/v1/two", remoteAddr, userID)
+	secondResponse := httptest.NewRecorder()
+	e.ServeHTTP(secondResponse, secondRequest)
+	assert.Equal(t, http.StatusTooManyRequests, secondResponse.Code)
+}
+
+func TestAPIRateLimiter_FallsBackToIPWithoutUserID(t *testing.T) {
+	settings := newRateLimitConfig(0.001, 1, time.Minute)
+	cfg := &config.Config{}
+	cfg.HTTP.APIRateLimit = settings
+	limiter, err := NewAPIRateLimiter(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, limiter)
+
+	e := echo.New()
+	e.IPExtractor = NewClientIPExtractor(&config.Config{})
+	e.Use(limiter)
+	e.POST("/api/v1/one", func(c echo.Context) error { return c.NoContent(http.StatusNoContent) })
+
+	firstRequest := newRateLimitRequest("/api/v1/one", "192.0.2.1:1000")
+	firstResponse := httptest.NewRecorder()
+	e.ServeHTTP(firstResponse, firstRequest)
+	assert.Equal(t, http.StatusNoContent, firstResponse.Code)
+
+	secondRequest := newRateLimitRequest("/api/v1/one", "192.0.2.1:1000")
+	secondResponse := httptest.NewRecorder()
+	e.ServeHTTP(secondResponse, secondRequest)
+	assert.Equal(t, http.StatusTooManyRequests, secondResponse.Code)
+
+	otherIPRequest := newRateLimitRequest("/api/v1/one", "192.0.2.2:1000")
+	otherIPResponse := httptest.NewRecorder()
+	e.ServeHTTP(otherIPResponse, otherIPRequest)
+	assert.Equal(t, http.StatusNoContent, otherIPResponse.Code)
+}
+
+func TestAPIRateLimiter_Disabled(t *testing.T) {
+	enabled := false
+	cfg := &config.Config{}
+	cfg.HTTP.APIRateLimit = &config.RateLimitConfig{Enabled: &enabled}
+
+	limiter, err := NewAPIRateLimiter(cfg)
+	require.NoError(t, err)
+	assert.Nil(t, limiter)
+}
+
+func TestAPIRateLimiter_RejectsInvalidConfiguration(t *testing.T) {
+	settings := newRateLimitConfig(-1, 1, time.Minute)
+	cfg := &config.Config{}
+	cfg.HTTP.APIRateLimit = settings
+
+	limiter, err := NewAPIRateLimiter(cfg)
+	assert.Nil(t, limiter)
+	assert.Error(t, err)
+}
+
 func newRateLimitRequest(target, remoteAddr string) *http.Request {
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, target, nil)
 	req.RemoteAddr = remoteAddr
@@ -80,4 +182,32 @@ func newRateLimitConfig(rate float64, burst int, expiresIn time.Duration) *confi
 		Burst:     &burst,
 		ExpiresIn: &expiresIn,
 	}
+}
+
+func newUserRateLimitEcho(limiter echo.MiddlewareFunc) *echo.Echo {
+	e := echo.New()
+	e.IPExtractor = NewClientIPExtractor(&config.Config{})
+	e.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			userID, err := uuid.Parse(c.Request().Header.Get("X-Test-User-ID"))
+			if err == nil {
+				c.Set(string(contextKeyUserID), userID)
+			}
+
+			return next(c)
+		}
+	})
+	e.Use(limiter)
+	handler := func(c echo.Context) error { return c.NoContent(http.StatusNoContent) }
+	e.POST("/api/v1/one", handler)
+	e.POST("/api/v1/two", handler)
+
+	return e
+}
+
+func newUserRateLimitRequest(target, remoteAddr string, userID uuid.UUID) *http.Request {
+	req := newRateLimitRequest(target, remoteAddr)
+	req.Header.Set("X-Test-User-ID", userID.String())
+
+	return req
 }

--- a/internal/delivery/api/middleware/rate_limit_test.go
+++ b/internal/delivery/api/middleware/rate_limit_test.go
@@ -167,6 +167,7 @@ func TestAPIRateLimiter_RejectsInvalidConfiguration(t *testing.T) {
 	limiter, err := NewAPIRateLimiter(cfg)
 	assert.Nil(t, limiter)
 	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "http.apiRateLimit.rate")
 }
 
 func newRateLimitRequest(target, remoteAddr string) *http.Request {

--- a/internal/delivery/api/router/router.go
+++ b/internal/delivery/api/router/router.go
@@ -67,7 +67,9 @@ func (r *router) RegisterRoutes(e *echo.Echo) error {
 		return err
 	}
 	r.registerAuthenticatedRootRoutes(e)
-	r.registerAPIV1Routes(e)
+	if err := r.registerAPIV1Routes(e); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -118,14 +120,24 @@ func (r *router) registerAuthenticatedRootRoutes(e *echo.Echo) {
 	}
 }
 
-func (r *router) registerAPIV1Routes(e *echo.Echo) {
+func (r *router) registerAPIV1Routes(e *echo.Echo) error {
+	apiRateLimiter, err := middleware.NewAPIRateLimiter(r.config)
+	if err != nil {
+		return fmt.Errorf("configure API rate limiter: %w", err)
+	}
+
 	apiV1 := e.Group("/api/v1")
 	apiV1.Use(r.authMiddleware.Authenticate)
+	if apiRateLimiter != nil {
+		apiV1.Use(apiRateLimiter)
+	}
 
 	r.registerAPIV1UserRoutes(apiV1)
 	r.registerAPIV1SharedRoutes(apiV1)
 	r.registerAPIV1ConsumerRoutes(apiV1)
 	r.registerAPIV1MerchantRoutes(apiV1)
+
+	return nil
 }
 
 func (r *router) registerAPIV1UserRoutes(apiV1 *echo.Group) {

--- a/internal/delivery/api/router/router_test.go
+++ b/internal/delivery/api/router/router_test.go
@@ -181,6 +181,30 @@ func TestRouter_DiscoveryValuesRequireAuthentication(t *testing.T) {
 	}
 }
 
+func TestRouter_APIV1AuthenticationRunsBeforeRateLimiter(t *testing.T) {
+	rate := 0.001
+	burst := 1
+	expiresIn := time.Minute
+	cfg := &config.Config{}
+	cfg.HTTP.APIRateLimit = &config.RateLimitConfig{
+		Rate:      &rate,
+		Burst:     &burst,
+		ExpiresIn: &expiresIn,
+	}
+	e := newRouterTestEchoWithConfig(cfg)
+
+	for i := range 2 {
+		req := newRouterTestRequest(http.MethodGet, "/api/v1/discovery/categories", "")
+		req.RemoteAddr = "192.0.2.1:1000"
+		rec := httptest.NewRecorder()
+
+		e.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusUnauthorized, rec.Code, "request %d should be rejected by authentication", i+1)
+		assert.NotEqual(t, http.StatusTooManyRequests, rec.Code)
+	}
+}
+
 func TestRouter_PublicMerchantSearchStillRequiresUserRole(t *testing.T) {
 	e := newRouterTestEcho()
 	req := newRouterTestRequest(http.MethodGet, "/api/v1/merchants", testMerchantToken)
@@ -291,6 +315,10 @@ func TestRouter_TestRoutesDisabledByDefault(t *testing.T) {
 }
 
 func newRouterTestEcho() *echo.Echo {
+	return newRouterTestEchoWithConfig(&config.Config{})
+}
+
+func newRouterTestEchoWithConfig(cfg *config.Config) *echo.Echo {
 	userID := uuid.New()
 	tokenSvc := &routerTestTokenService{
 		claims: map[string]*service.Claims{
@@ -308,9 +336,9 @@ func newRouterTestEcho() *echo.Echo {
 	}
 
 	e := echo.New()
-	e.IPExtractor = apimiddleware.NewClientIPExtractor(&config.Config{})
+	e.IPExtractor = apimiddleware.NewClientIPExtractor(cfg)
 	e.Validator = apivalidator.New()
-	authMiddleware := apimiddleware.NewAuthMiddleware(tokenSvc, &config.Config{})
+	authMiddleware := apimiddleware.NewAuthMiddleware(tokenSvc, cfg)
 	r := NewRouter(RouterParams{
 		UserHandler: handler.NewUserHandler(handler.UserHandlerParams{
 			ProfileUC: &routerTestProfileUsecase{},
@@ -321,7 +349,7 @@ func newRouterTestEcho() *echo.Echo {
 			Logger:      slog.Default(),
 		}),
 		AuthMiddleware: authMiddleware,
-		Config:         &config.Config{},
+		Config:         cfg,
 	})
 	if err := r.RegisterRoutes(e); err != nil {
 		panic(err)

--- a/internal/infra/persistence/postgres/menu_repository.go
+++ b/internal/infra/persistence/postgres/menu_repository.go
@@ -119,7 +119,11 @@ func (repo *menuRepository) ListMenuItemsByMerchant(ctx context.Context, merchan
 
 	dataQuery := menuItem.WithContext(ctx).
 		Where(conditions...).
-		Order(menuItem.DisplayOrder.Asc(), menuItem.CreatedAt.Asc())
+		Order(
+			menuItem.DisplayOrder.Asc(),
+			menuItem.CreatedAt.Asc(),
+			menuItem.ID.Asc(),
+		)
 	if filter.Limit > 0 {
 		dataQuery = dataQuery.Limit(filter.Limit)
 	}

--- a/internal/infra/persistence/postgres/menu_repository_test.go
+++ b/internal/infra/persistence/postgres/menu_repository_test.go
@@ -1,0 +1,57 @@
+package postgres
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"radar/internal/domain/repository"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+func TestMenuRepository_ListMenuItemsByMerchantQuery_UsesStableOrdering(t *testing.T) {
+	repo := newDryRunMenuRepository(t)
+
+	sql := menuListSQL(repo, repository.MenuItemListFilter{
+		Limit:  20,
+		Offset: 20,
+	})
+
+	require.Contains(t, sql, "ORDER BY menu_items.display_order ASC,menu_items.created_at ASC,menu_items.id ASC")
+}
+
+type dryRunMenuRepository struct {
+	repo      *menuRepository
+	sqlLogger *captureSQLLogger
+}
+
+func newDryRunMenuRepository(t *testing.T) *dryRunMenuRepository {
+	t.Helper()
+
+	sqlLogger := &captureSQLLogger{}
+	db, err := gorm.Open(postgres.New(postgres.Config{
+		DSN:                  "host=localhost user=test password=test dbname=test sslmode=disable",
+		PreferSimpleProtocol: true,
+	}), &gorm.Config{DryRun: true, DisableAutomaticPing: true, Logger: sqlLogger})
+	require.NoError(t, err)
+
+	repo, ok := NewMenuRepository(db).(*menuRepository)
+	require.True(t, ok)
+
+	return &dryRunMenuRepository{repo: repo, sqlLogger: sqlLogger}
+}
+
+func menuListSQL(dryRun *dryRunMenuRepository, filter repository.MenuItemListFilter) string {
+	dryRun.sqlLogger.queries = nil
+
+	_, _, _ = dryRun.repo.ListMenuItemsByMerchant(context.Background(), uuid.New(), filter)
+
+	sql := strings.Join(dryRun.sqlLogger.queries, " ")
+	sql = strings.ReplaceAll(sql, `"`, "")
+
+	return strings.Join(strings.Fields(sql), " ")
+}

--- a/internal/infra/persistence/postgres/notification_repository.go
+++ b/internal/infra/persistence/postgres/notification_repository.go
@@ -68,7 +68,10 @@ func (repo *notificationRepository) FindNotificationByID(ctx context.Context, id
 func (repo *notificationRepository) FindNotificationsByMerchant(ctx context.Context, merchantID uuid.UUID, limit, offset int) ([]*entity.MerchantLocationNotification, error) {
 	query := repo.q.MerchantLocationNotificationModel.WithContext(ctx).
 		Where(repo.q.MerchantLocationNotificationModel.MerchantID.Eq(merchantID)).
-		Order(repo.q.MerchantLocationNotificationModel.PublishedAt.Desc())
+		Order(
+			repo.q.MerchantLocationNotificationModel.PublishedAt.Desc(),
+			repo.q.MerchantLocationNotificationModel.ID.Asc(),
+		)
 
 	if limit > 0 {
 		query = query.Limit(limit)

--- a/internal/infra/persistence/postgres/notification_repository_test.go
+++ b/internal/infra/persistence/postgres/notification_repository_test.go
@@ -1,0 +1,52 @@
+package postgres
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+func TestNotificationRepository_FindNotificationsByMerchantQuery_UsesStableOrdering(t *testing.T) {
+	repo := newDryRunNotificationRepository(t)
+
+	sql := notificationListSQL(repo, uuid.New(), 20, 20)
+
+	require.Contains(t, sql, "ORDER BY merchant_location_notifications.published_at DESC,merchant_location_notifications.id ASC")
+}
+
+type dryRunNotificationRepository struct {
+	repo      *notificationRepository
+	sqlLogger *captureSQLLogger
+}
+
+func newDryRunNotificationRepository(t *testing.T) *dryRunNotificationRepository {
+	t.Helper()
+
+	sqlLogger := &captureSQLLogger{}
+	db, err := gorm.Open(postgres.New(postgres.Config{
+		DSN:                  "host=localhost user=test password=test dbname=test sslmode=disable",
+		PreferSimpleProtocol: true,
+	}), &gorm.Config{DryRun: true, DisableAutomaticPing: true, Logger: sqlLogger})
+	require.NoError(t, err)
+
+	repo, ok := NewNotificationRepository(db).(*notificationRepository)
+	require.True(t, ok)
+
+	return &dryRunNotificationRepository{repo: repo, sqlLogger: sqlLogger}
+}
+
+func notificationListSQL(dryRun *dryRunNotificationRepository, merchantID uuid.UUID, limit, offset int) string {
+	dryRun.sqlLogger.queries = nil
+
+	_, _ = dryRun.repo.FindNotificationsByMerchant(context.Background(), merchantID, limit, offset)
+
+	sql := strings.Join(dryRun.sqlLogger.queries, " ")
+	sql = strings.ReplaceAll(sql, `"`, "")
+
+	return strings.Join(strings.Fields(sql), " ")
+}


### PR DESCRIPTION
## Summary

- Stabilize paginated menu and notification ordering with primary-key tiebreakers.
- Add independent user-keyed in-process rate limiting for authenticated `/api/v1/*` routes.
- Ensure authentication runs before API rate limiting and preserve IP-keyed `/auth/*` and `/oauth/*` limits.
- Document the API limiter defaults and per-instance behavior.

## Verification

- `go build ./...`
- `go vet ./...`
- `go test -count=1 ./...` (643 passed)
- `golangci-lint run ./internal/... ./config/...`
- `gofmt -l` and `git diff --check`
- Both required mutation checks were independently verified to fail precisely.

## Follow-up

`/user/profile`, `/auth/refresh`, and `/auth/logout` remain unchanged and are out of scope for this pull request.

k6, shellcheck, and actionlint were not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added separate in-process rate limiting for authenticated API requests, with per-user limits and client-IP fallback.
  * Added configurable API rate-limit defaults, including request rate, burst capacity, and visitor cleanup settings.
* **Bug Fixes**
  * API, menu, and notification listings now use stable ordering when timestamps or display positions match.
  * Invalid rate-limit configurations are rejected, while explicitly disabled limits remain disabled.
  * Authentication is evaluated before rate limiting for unauthenticated discovery requests.
* **Documentation**
  * Documented API rate-limiting behavior, defaults, and deployment considerations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->