### PR TITLE
fix: key session rate limits by user

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -20,21 +20,24 @@ import (
 )
 
 const (
-	defaultPath                  = "."
-	defaultMaxRequestBodySize    = "100KB"
-	postgresMasterDSNEnvKey      = "POSTGRES_MASTER_DSN"
-	defaultAccessTokenTTL        = 15 * time.Minute
-	defaultRefreshTokenTTL       = 7 * 24 * time.Hour
-	defaultOnboardingTokenTTL    = 10 * time.Minute
-	defaultLinkingTokenTTL       = 10 * time.Minute
-	defaultNotificationTimeout   = 10 * time.Second
-	defaultDeviceCleanupTimeout  = 5 * time.Minute
-	defaultRateLimitRate         = 10.0
-	defaultRateLimitBurst        = 30
-	defaultRateLimitExpiresIn    = 3 * time.Minute
-	defaultAPIRateLimitRate      = 20.0
-	defaultAPIRateLimitBurst     = 60
-	defaultAPIRateLimitExpiresIn = 3 * time.Minute
+	defaultPath                      = "."
+	defaultMaxRequestBodySize        = "100KB"
+	postgresMasterDSNEnvKey          = "POSTGRES_MASTER_DSN"
+	defaultAccessTokenTTL            = 15 * time.Minute
+	defaultRefreshTokenTTL           = 7 * 24 * time.Hour
+	defaultOnboardingTokenTTL        = 10 * time.Minute
+	defaultLinkingTokenTTL           = 10 * time.Minute
+	defaultNotificationTimeout       = 10 * time.Second
+	defaultDeviceCleanupTimeout      = 5 * time.Minute
+	defaultRateLimitRate             = 10.0
+	defaultRateLimitBurst            = 30
+	defaultRateLimitExpiresIn        = 3 * time.Minute
+	defaultAPIRateLimitRate          = 20.0
+	defaultAPIRateLimitBurst         = 60
+	defaultAPIRateLimitExpiresIn     = 3 * time.Minute
+	defaultSessionRateLimitRate      = 2.0
+	defaultSessionRateLimitBurst     = 20
+	defaultSessionRateLimitExpiresIn = 3 * time.Minute
 )
 
 type Config struct {
@@ -53,6 +56,7 @@ type Config struct {
 		CORSAllowedOrigins string           `json:"corsAllowedOrigins" yaml:"corsAllowedOrigins"`
 		RateLimit          *RateLimitConfig `json:"rateLimit" yaml:"rateLimit"`
 		APIRateLimit       *RateLimitConfig `json:"apiRateLimit" yaml:"apiRateLimit"`
+		SessionRateLimit   *RateLimitConfig `json:"sessionRateLimit" yaml:"sessionRateLimit"`
 		Timeouts           struct {
 			ReadTimeout       time.Duration `json:"readTimeout" yaml:"readTimeout"`
 			ReadHeaderTimeout time.Duration `json:"readHeaderTimeout" yaml:"readHeaderTimeout"`
@@ -166,14 +170,24 @@ func DefaultAPIRateLimitConfig() RateLimitConfig {
 	}
 }
 
+// DefaultSessionRateLimitConfig returns the default session rate limiter configuration.
+func DefaultSessionRateLimitConfig() RateLimitConfig {
+	enabled := true
+	rate := defaultSessionRateLimitRate
+	burst := defaultSessionRateLimitBurst
+	expiresIn := defaultSessionRateLimitExpiresIn
+
+	return RateLimitConfig{
+		Enabled:   &enabled,
+		Rate:      &rate,
+		Burst:     &burst,
+		ExpiresIn: &expiresIn,
+	}
+}
+
 // IsEnabled reports whether the rate limiter is enabled. A missing value defaults to enabled.
 func (cfg RateLimitConfig) IsEnabled() bool {
 	return cfg.Enabled == nil || *cfg.Enabled
-}
-
-// Validate checks the rate limiter values.
-func (cfg RateLimitConfig) Validate() error {
-	return cfg.ValidateAt("http.rateLimit")
 }
 
 // ValidateAt checks the rate limiter values and reports errors under path.
@@ -409,12 +423,19 @@ func (cfg *Config) Validate() error {
 	}
 
 	if cfg.HTTP.RateLimit != nil {
-		if err := cfg.HTTP.RateLimit.Validate(); err != nil {
+		if err := cfg.HTTP.RateLimit.ValidateAt("http.rateLimit"); err != nil {
 			return err
 		}
 	}
 	if cfg.HTTP.APIRateLimit != nil {
-		return cfg.HTTP.APIRateLimit.ValidateAt("http.apiRateLimit")
+		if err := cfg.HTTP.APIRateLimit.ValidateAt("http.apiRateLimit"); err != nil {
+			return err
+		}
+	}
+	if cfg.HTTP.SessionRateLimit != nil {
+		if err := cfg.HTTP.SessionRateLimit.ValidateAt("http.sessionRateLimit"); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -427,6 +448,7 @@ func applyHTTPDefaults(cfg *Config) {
 
 	applyRateLimitDefaults(&cfg.HTTP.RateLimit, DefaultRateLimitConfig())
 	applyRateLimitDefaults(&cfg.HTTP.APIRateLimit, DefaultAPIRateLimitConfig())
+	applyRateLimitDefaults(&cfg.HTTP.SessionRateLimit, DefaultSessionRateLimitConfig())
 }
 
 func applyRateLimitDefaults(cfg **RateLimitConfig, defaults RateLimitConfig) {

--- a/config/rate_limit_test.go
+++ b/config/rate_limit_test.go
@@ -52,6 +52,28 @@ func TestApplyDefaults_APIRateLimit(t *testing.T) {
 	}
 }
 
+func TestApplyDefaults_SessionRateLimit(t *testing.T) {
+	cfg := &Config{}
+
+	ApplyDefaults(cfg)
+
+	if cfg.HTTP.SessionRateLimit == nil {
+		t.Fatal("expected session rate limit defaults")
+	}
+	if !cfg.HTTP.SessionRateLimit.IsEnabled() {
+		t.Fatal("expected session rate limit to be enabled by default")
+	}
+	if cfg.HTTP.SessionRateLimit.Rate == nil || *cfg.HTTP.SessionRateLimit.Rate != 2 {
+		t.Fatalf("Rate = %v, want 2", cfg.HTTP.SessionRateLimit.Rate)
+	}
+	if cfg.HTTP.SessionRateLimit.Burst == nil || *cfg.HTTP.SessionRateLimit.Burst != 20 {
+		t.Fatalf("Burst = %v, want 20", cfg.HTTP.SessionRateLimit.Burst)
+	}
+	if cfg.HTTP.SessionRateLimit.ExpiresIn == nil || *cfg.HTTP.SessionRateLimit.ExpiresIn != 3*time.Minute {
+		t.Fatalf("ExpiresIn = %v, want 3m", cfg.HTTP.SessionRateLimit.ExpiresIn)
+	}
+}
+
 func TestApplyDefaults_RateLimitPreservesDisabledValue(t *testing.T) {
 	enabled := false
 	cfg := &Config{}
@@ -96,14 +118,36 @@ func TestConfigValidateRejectsInvalidAPIRateLimit(t *testing.T) {
 	if !strings.Contains(err.Error(), "http.apiRateLimit.rate") {
 		t.Fatalf("Validate() error = %v, want API rate-limit path", err)
 	}
+	if strings.Contains(err.Error(), "http.rateLimit") {
+		t.Fatalf("Validate() error = %v, must not use authentication rate-limit path", err)
+	}
+}
+
+func TestConfigValidateRejectsInvalidSessionRateLimit(t *testing.T) {
+	settings := newRateLimitConfig(0, 1, time.Minute)
+	cfg := &Config{}
+	cfg.HTTP.SessionRateLimit = &settings
+
+	ApplyDefaults(cfg)
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("Validate() expected an error for invalid session rate-limit values")
+	}
+	if !strings.Contains(err.Error(), "http.sessionRateLimit.rate") {
+		t.Fatalf("Validate() error = %v, want session rate-limit path", err)
+	}
+	if strings.Contains(err.Error(), "http.rateLimit") {
+		t.Fatalf("Validate() error = %v, must not use authentication rate-limit path", err)
+	}
 }
 
 func TestRateLimitConfigValidateUsesDefaultAndExplicitPaths(t *testing.T) {
 	settings := newRateLimitConfig(0, 1, time.Minute)
 
-	err := settings.Validate()
+	err := settings.ValidateAt("http.rateLimit")
 	if err == nil || !strings.Contains(err.Error(), "http.rateLimit.rate") {
-		t.Fatalf("Validate() error = %v, want authentication rate-limit path", err)
+		t.Fatalf("ValidateAt() error = %v, want authentication rate-limit path", err)
 	}
 
 	err = settings.ValidateAt("http.apiRateLimit")
@@ -142,7 +186,7 @@ func TestRateLimitConfigValidateRejectsInvalidEnabledValues(t *testing.T) {
 	}
 
 	for _, cfg := range testCases {
-		if err := cfg.Validate(); err == nil {
+		if err := cfg.ValidateAt("http.rateLimit"); err == nil {
 			t.Fatalf("Validate(%+v) expected an error", cfg)
 		}
 	}
@@ -161,7 +205,7 @@ func TestRateLimitConfigValidateRejectsNonFiniteRate(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			cfg := newRateLimitConfig(testCase.rate, 1, time.Minute)
-			if err := cfg.Validate(); err == nil {
+			if err := cfg.ValidateAt("http.rateLimit"); err == nil {
 				t.Fatalf("Validate(%+v) expected an error", cfg)
 			}
 		})

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -249,15 +249,25 @@ value disables CORS instead of allowing every origin. Cloud Run releases may
 leave this variable empty when no browser cross-origin client is required;
 browser clients must otherwise be configured explicitly in each environment.
 
-Authentication endpoints use one configurable in-process Echo rate limiter for
-`/auth/*` and `/oauth/*`. The defaults are 10 requests/second, a burst of 30,
-and three-minute visitor cleanup. The limiter is keyed by the client IP, is
-local to each Cloud Run instance, and is not a global distributed limiter.
-`HTTP_RATELIMIT_ENABLED=false` disables it explicitly. In Cloudflare-backed
-environments the client IP comes from the authenticated `CF-Connecting-IP`
-header; direct environments ignore forwarded IP headers and use the network
-peer address. This application-layer limiter does not replace a Cloudflare-wide
-rate-limiting rule.
+Credential authentication endpoints and `/oauth/*` use one configurable
+in-process Echo rate limiter. It covers registration, login, onboarding, and
+provider-linking routes under `/auth`, plus OAuth callbacks. The defaults are
+10 requests/second, a burst of 30, and three-minute visitor cleanup. The
+limiter is keyed by the client IP, is local to each Cloud Run instance, and is
+not a global distributed limiter. `HTTP_RATELIMIT_ENABLED=false` disables it
+explicitly. In Cloudflare-backed environments the client IP comes from the
+authenticated `CF-Connecting-IP` header; direct environments ignore forwarded
+IP headers and use the network peer address. This application-layer limiter
+does not replace a Cloudflare-wide rate-limiting rule.
+
+`/auth/refresh` and `/auth/logout` use a separate configurable in-process Echo
+session rate limiter. When the refresh token is valid, it is keyed by the user
+ID in that token; invalid or missing tokens fall back to the client IP. Its
+defaults are 2 requests/second, a burst of 20, and three-minute visitor
+cleanup. It is local to each Cloud Run instance and is intended to contain
+runaway clients rather than replace credential lockout or a Cloudflare-wide
+rate-limiting rule. This phase does not add separate environment-variable
+overrides.
 
 Authenticated `/api/v1/*` endpoints use a separate in-process Echo rate limiter
 keyed by the authenticated user ID. Its defaults are 20 requests/second, a

--- a/internal/delivery/api/middleware/auth.go
+++ b/internal/delivery/api/middleware/auth.go
@@ -1,12 +1,14 @@
 package middleware
 
 import (
+	"encoding/json"
 	"strings"
 
 	"radar/config"
 	"radar/internal/delivery/api/response"
 	"radar/internal/domain/entity"
 	"radar/internal/domain/service"
+	"radar/internal/usecase"
 
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
@@ -49,6 +51,30 @@ type AuthMiddleware struct {
 // NewAuthMiddleware is the constructor for AuthMiddleware.
 func NewAuthMiddleware(tokenSvc service.TokenService, cfg *config.Config) *AuthMiddleware {
 	return &AuthMiddleware{tokenSvc: tokenSvc, cfg: cfg}
+}
+
+// RefreshTokenSubject returns the user in the request's refresh token, if any.
+func (m *AuthMiddleware) RefreshTokenSubject(c echo.Context) (uuid.UUID, bool) {
+	if c == nil {
+		return uuid.Nil, false
+	}
+
+	rawBody, ok := c.Get(capturedRequestBodyKey).([]byte)
+	if !ok || len(rawBody) == 0 {
+		return uuid.Nil, false
+	}
+
+	var input usecase.RefreshTokenInput
+	if err := json.Unmarshal(rawBody, &input); err != nil || input.RefreshToken == "" {
+		return uuid.Nil, false
+	}
+
+	claims, err := m.tokenSvc.ValidateToken(input.RefreshToken)
+	if err != nil || claims == nil || claims.Type != service.TokenTypeRefresh {
+		return uuid.Nil, false
+	}
+
+	return claims.UserID, true
 }
 
 // Authenticate is the core middleware function that validates the JWT access token.

--- a/internal/delivery/api/middleware/rate_limit.go
+++ b/internal/delivery/api/middleware/rate_limit.go
@@ -5,6 +5,7 @@ import (
 
 	"radar/config"
 
+	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	echomiddleware "github.com/labstack/echo/v4/middleware"
 	"golang.org/x/time/rate"
@@ -17,7 +18,7 @@ func NewAuthRateLimiter(cfg *config.Config) (echo.MiddlewareFunc, error) {
 	if cfg != nil && cfg.HTTP.RateLimit != nil {
 		settings = *cfg.HTTP.RateLimit
 	}
-	if err := settings.Validate(); err != nil {
+	if err := settings.ValidateAt("http.rateLimit"); err != nil {
 		return nil, fmt.Errorf("invalid authentication rate limit configuration: %w", err)
 	}
 	if !settings.IsEnabled() {
@@ -33,6 +34,43 @@ func NewAuthRateLimiter(cfg *config.Config) (echo.MiddlewareFunc, error) {
 	return echomiddleware.RateLimiterWithConfig(echomiddleware.RateLimiterConfig{
 		Store: store,
 		IdentifierExtractor: func(c echo.Context) (string, error) {
+			return c.RealIP(), nil
+		},
+	}), nil
+}
+
+// NewSessionRateLimiter creates the in-process limiter shared by refresh and logout routes.
+// It keys requests by the refresh-token user ID and falls back to the client IP.
+func NewSessionRateLimiter(
+	cfg *config.Config,
+	identify func(echo.Context) (uuid.UUID, bool),
+) (echo.MiddlewareFunc, error) {
+	settings := config.DefaultSessionRateLimitConfig()
+	if cfg != nil && cfg.HTTP.SessionRateLimit != nil {
+		settings = *cfg.HTTP.SessionRateLimit
+	}
+	if err := settings.ValidateAt("http.sessionRateLimit"); err != nil {
+		return nil, fmt.Errorf("invalid session rate limit configuration: %w", err)
+	}
+	if !settings.IsEnabled() {
+		return nil, nil
+	}
+
+	store := echomiddleware.NewRateLimiterMemoryStoreWithConfig(echomiddleware.RateLimiterMemoryStoreConfig{
+		Rate:      rate.Limit(*settings.Rate),
+		Burst:     *settings.Burst,
+		ExpiresIn: *settings.ExpiresIn,
+	})
+
+	return echomiddleware.RateLimiterWithConfig(echomiddleware.RateLimiterConfig{
+		Store: store,
+		IdentifierExtractor: func(c echo.Context) (string, error) {
+			if identify != nil {
+				if userID, ok := identify(c); ok {
+					return userID.String(), nil
+				}
+			}
+
 			return c.RealIP(), nil
 		},
 	}), nil

--- a/internal/delivery/api/middleware/rate_limit_test.go
+++ b/internal/delivery/api/middleware/rate_limit_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"radar/config"
+	"radar/internal/domain/service"
 
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
@@ -170,6 +172,84 @@ func TestAPIRateLimiter_RejectsInvalidConfiguration(t *testing.T) {
 	assert.Contains(t, err.Error(), "http.apiRateLimit.rate")
 }
 
+func TestSessionRateLimiter_UsesSeparateBucketPerRefreshTokenSubject(t *testing.T) {
+	settings := newRateLimitConfig(0.001, 1, time.Minute)
+	cfg := &config.Config{}
+	cfg.HTTP.SessionRateLimit = settings
+	userA := uuid.New()
+	userB := uuid.New()
+	tokenSvc := &rateLimitTestTokenService{claims: map[string]*service.Claims{
+		"refresh-a": {UserID: userA, Type: service.TokenTypeRefresh},
+		"refresh-b": {UserID: userB, Type: service.TokenTypeRefresh},
+	}}
+	e := newSessionRateLimitEcho(t, cfg, tokenSvc)
+	remoteAddr := "192.0.2.1:1000"
+
+	firstUserAResponse := serveSessionRateLimitRequest(e, newSessionRateLimitRequest("refresh-a", remoteAddr))
+	assert.Equal(t, http.StatusNoContent, firstUserAResponse.Code)
+
+	firstUserBResponse := serveSessionRateLimitRequest(e, newSessionRateLimitRequest("refresh-b", remoteAddr))
+	assert.Equal(t, http.StatusNoContent, firstUserBResponse.Code)
+
+	secondUserAResponse := serveSessionRateLimitRequest(e, newSessionRateLimitRequest("refresh-a", remoteAddr))
+	assert.Equal(t, http.StatusTooManyRequests, secondUserAResponse.Code)
+}
+
+func TestSessionRateLimiter_FallsBackToIPForInvalidOrMissingToken(t *testing.T) {
+	for _, testCase := range []struct {
+		name  string
+		token string
+	}{
+		{name: "invalid token", token: "invalid-token"},
+		{name: "missing token", token: ""},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			settings := newRateLimitConfig(0.001, 1, time.Minute)
+			cfg := &config.Config{}
+			cfg.HTTP.SessionRateLimit = settings
+			e := newSessionRateLimitEcho(t, cfg, &rateLimitTestTokenService{claims: map[string]*service.Claims{}})
+
+			firstResponse := serveSessionRateLimitRequest(e, newSessionRateLimitRequest(testCase.token, "192.0.2.1:1000"))
+			assert.Equal(t, http.StatusNoContent, firstResponse.Code)
+
+			secondResponse := serveSessionRateLimitRequest(e, newSessionRateLimitRequest(testCase.token, "192.0.2.1:1000"))
+			assert.Equal(t, http.StatusTooManyRequests, secondResponse.Code)
+
+			otherIPResponse := serveSessionRateLimitRequest(e, newSessionRateLimitRequest(testCase.token, "192.0.2.2:1000"))
+			assert.Equal(t, http.StatusNoContent, otherIPResponse.Code)
+		})
+	}
+}
+
+func TestSessionRateLimiter_DoesNotAcceptAccessTokenAsSubject(t *testing.T) {
+	settings := newRateLimitConfig(0.001, 1, time.Minute)
+	cfg := &config.Config{}
+	cfg.HTTP.SessionRateLimit = settings
+	tokenSvc := &rateLimitTestTokenService{claims: map[string]*service.Claims{
+		"access-token": {UserID: uuid.New(), Type: service.TokenTypeAccess},
+	}}
+	e := newSessionRateLimitEcho(t, cfg, tokenSvc)
+	remoteAddr := "192.0.2.1:1000"
+
+	accessTokenResponse := serveSessionRateLimitRequest(e, newSessionRateLimitRequest("access-token", remoteAddr))
+	assert.Equal(t, http.StatusNoContent, accessTokenResponse.Code)
+
+	missingTokenResponse := serveSessionRateLimitRequest(e, newSessionRateLimitRequest("", remoteAddr))
+	assert.Equal(t, http.StatusTooManyRequests, missingTokenResponse.Code)
+}
+
+func TestSessionRateLimiter_RejectsInvalidConfiguration(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.HTTP.SessionRateLimit = newRateLimitConfig(-1, 1, time.Minute)
+
+	limiter, err := NewSessionRateLimiter(cfg, func(echo.Context) (uuid.UUID, bool) {
+		return uuid.Nil, false
+	})
+	assert.Nil(t, limiter)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "http.sessionRateLimit.rate")
+}
+
 func newRateLimitRequest(target, remoteAddr string) *http.Request {
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, target, nil)
 	req.RemoteAddr = remoteAddr
@@ -211,4 +291,76 @@ func newUserRateLimitRequest(target, remoteAddr string, userID uuid.UUID) *http.
 	req.Header.Set("X-Test-User-ID", userID.String())
 
 	return req
+}
+
+type rateLimitTestTokenService struct {
+	claims map[string]*service.Claims
+}
+
+func (s *rateLimitTestTokenService) GenerateTokens(uuid.UUID, []string) (string, string, error) {
+	return "", "", nil
+}
+
+func (s *rateLimitTestTokenService) ValidateToken(token string) (*service.Claims, error) {
+	claims, ok := s.claims[token]
+	if !ok {
+		return nil, assert.AnError
+	}
+
+	return claims, nil
+}
+
+func (s *rateLimitTestTokenService) GenerateOnboardingToken(uuid.UUID) (string, error) {
+	return "", nil
+}
+
+func (s *rateLimitTestTokenService) GenerateLinkingToken(uuid.UUID, string, string, string, string) (string, error) {
+	return "", nil
+}
+
+func (s *rateLimitTestTokenService) GetRefreshTokenDuration() time.Duration {
+	return time.Hour
+}
+
+func (s *rateLimitTestTokenService) HashToken(token string) string {
+	return token
+}
+
+func (s *rateLimitTestTokenService) RotateTokens(uuid.UUID, []string) (string, string, string, error) {
+	return "", "", "", nil
+}
+
+func newSessionRateLimitEcho(t *testing.T, cfg *config.Config, tokenSvc service.TokenService) *echo.Echo {
+	t.Helper()
+	authMiddleware := NewAuthMiddleware(tokenSvc, cfg)
+	limiter, err := NewSessionRateLimiter(cfg, authMiddleware.RefreshTokenSubject)
+	require.NoError(t, err)
+	require.NotNil(t, limiter)
+
+	e := echo.New()
+	e.IPExtractor = NewClientIPExtractor(&config.Config{})
+	e.Use(CaptureRequestBodyForErrorLog)
+	e.Use(limiter)
+	e.POST("/auth/refresh", func(c echo.Context) error { return c.NoContent(http.StatusNoContent) })
+
+	return e
+}
+
+func newSessionRateLimitRequest(refreshToken, remoteAddr string) *http.Request {
+	body := "{}"
+	if refreshToken != "" {
+		body = `{"refresh_token":"` + refreshToken + `"}`
+	}
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/auth/refresh", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	req.RemoteAddr = remoteAddr
+
+	return req
+}
+
+func serveSessionRateLimitRequest(e *echo.Echo, req *http.Request) *httptest.ResponseRecorder {
+	response := httptest.NewRecorder()
+	e.ServeHTTP(response, req)
+
+	return response
 }

--- a/internal/delivery/api/router/router.go
+++ b/internal/delivery/api/router/router.go
@@ -79,19 +79,30 @@ func (r *router) registerPublicRoutes(e *echo.Echo) error {
 	if err != nil {
 		return fmt.Errorf("configure auth rate limiter: %w", err)
 	}
+	sessionRateLimiter, err := middleware.NewSessionRateLimiter(r.config, r.authMiddleware.RefreshTokenSubject)
+	if err != nil {
+		return fmt.Errorf("configure session rate limiter: %w", err)
+	}
 
-	authGroup := e.Group("/auth")
+	credentialGroup := e.Group("/auth")
 	if authRateLimiter != nil {
-		authGroup.Use(authRateLimiter)
+		credentialGroup.Use(authRateLimiter)
 	}
 	{
-		authGroup.POST("/register/user", r.userHandler.RegisterUser)
-		authGroup.POST("/register/merchant", r.userHandler.RegisterMerchant)
-		authGroup.POST("/login", r.userHandler.Login)
-		authGroup.POST("/onboarding/merchant", r.userHandler.CompleteMerchantOnboarding)
-		authGroup.POST("/link-provider", r.userHandler.LinkProvider)
-		authGroup.POST("/refresh", r.userHandler.RefreshToken)
-		authGroup.POST("/logout", r.userHandler.Logout)
+		credentialGroup.POST("/register/user", r.userHandler.RegisterUser)
+		credentialGroup.POST("/register/merchant", r.userHandler.RegisterMerchant)
+		credentialGroup.POST("/login", r.userHandler.Login)
+		credentialGroup.POST("/onboarding/merchant", r.userHandler.CompleteMerchantOnboarding)
+		credentialGroup.POST("/link-provider", r.userHandler.LinkProvider)
+	}
+
+	sessionGroup := e.Group("/auth")
+	if sessionRateLimiter != nil {
+		sessionGroup.Use(sessionRateLimiter)
+	}
+	{
+		sessionGroup.POST("/refresh", r.userHandler.RefreshToken)
+		sessionGroup.POST("/logout", r.userHandler.Logout)
 	}
 
 	oauthGroup := e.Group("/oauth")

--- a/internal/delivery/api/router/router_test.go
+++ b/internal/delivery/api/router/router_test.go
@@ -27,6 +27,7 @@ import (
 const (
 	testUserToken     = "user-token"
 	testMerchantToken = "merchant-token"
+	testRefreshToken  = "refresh-token"
 )
 
 type routerTestTokenService struct {
@@ -136,6 +137,64 @@ func (uc *routerTestProfileUsecase) SwitchToMerchant(context.Context, uuid.UUID,
 
 func (uc *routerTestProfileUsecase) GetUserRole(context.Context, uuid.UUID) ([]string, error) {
 	return nil, nil
+}
+
+type routerTestUserUsecase struct {
+	refreshToken string
+}
+
+func (uc *routerTestUserUsecase) RegisterUser(context.Context, *usecase.RegisterUserInput) (*usecase.AuthResult, error) {
+	return &usecase.AuthResult{}, nil
+}
+
+func (uc *routerTestUserUsecase) RegisterMerchant(context.Context, *usecase.RegisterMerchantInput) (*usecase.AuthResult, error) {
+	return &usecase.AuthResult{}, nil
+}
+
+func (uc *routerTestUserUsecase) Login(context.Context, *usecase.LoginInput) (*usecase.AuthResult, error) {
+	return &usecase.AuthResult{}, nil
+}
+
+func (uc *routerTestUserUsecase) RefreshToken(_ context.Context, input *usecase.RefreshTokenInput) (*usecase.RefreshTokenOutput, error) {
+	uc.refreshToken = input.RefreshToken
+
+	return &usecase.RefreshTokenOutput{AccessToken: "access-token", RefreshToken: "refresh-token"}, nil
+}
+
+func (uc *routerTestUserUsecase) Logout(context.Context, *usecase.LogoutInput) error {
+	return nil
+}
+
+func (uc *routerTestUserUsecase) GoogleCallback(context.Context, *usecase.GoogleCallbackInput) (*usecase.AuthResult, error) {
+	return &usecase.AuthResult{}, nil
+}
+
+func (uc *routerTestUserUsecase) CompleteMerchantOnboarding(context.Context, *usecase.CompleteMerchantOnboardingInput) (*usecase.AuthResult, error) {
+	return &usecase.AuthResult{}, nil
+}
+
+func (uc *routerTestUserUsecase) LinkProvider(context.Context, usecase.LinkProviderInput) (*usecase.LinkProviderOutput, error) {
+	return &usecase.LinkProviderOutput{}, nil
+}
+
+func (uc *routerTestUserUsecase) LogoutAllDevices(context.Context, uuid.UUID) error {
+	return nil
+}
+
+func (uc *routerTestUserUsecase) GetActiveSessions(context.Context, uuid.UUID) ([]*entity.RefreshToken, error) {
+	return nil, nil
+}
+
+func (uc *routerTestUserUsecase) RevokeSession(context.Context, uuid.UUID, uuid.UUID) error {
+	return nil
+}
+
+func (uc *routerTestUserUsecase) LinkGoogleAccount(context.Context, uuid.UUID, string) error {
+	return nil
+}
+
+func (uc *routerTestUserUsecase) UnlinkGoogleAccount(context.Context, uuid.UUID) error {
+	return nil
 }
 
 func TestRouter_DiscoveryValuesAllowMerchantRole(t *testing.T) {
@@ -298,6 +357,74 @@ func TestRouter_AuthenticationRoutesAreRateLimitedPerClientIP(t *testing.T) {
 	assert.Equal(t, http.StatusOK, healthResponse.Code)
 }
 
+func TestRouter_RefreshRoutePreservesRequestBody(t *testing.T) {
+	rate := 0.001
+	burst := 1
+	expiresIn := time.Minute
+	cfg := &config.Config{}
+	cfg.HTTP.SessionRateLimit = &config.RateLimitConfig{
+		Rate:      &rate,
+		Burst:     &burst,
+		ExpiresIn: &expiresIn,
+	}
+	userUC := &routerTestUserUsecase{}
+	e := newRouterTestEchoWithConfigAndUserUsecase(cfg, userUC)
+
+	req := httptest.NewRequestWithContext(
+		context.Background(),
+		http.MethodPost,
+		"/auth/refresh",
+		strings.NewReader(`{"refresh_token":"`+testRefreshToken+`"}`),
+	)
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	req.RemoteAddr = "192.0.2.1:1000"
+	rec := httptest.NewRecorder()
+
+	e.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, testRefreshToken, userUC.refreshToken)
+}
+
+func TestRouter_SessionRoutesHaveIndependentCredentialRateLimiter(t *testing.T) {
+	rate := 0.001
+	burst := 1
+	expiresIn := time.Minute
+	cfg := &config.Config{}
+	cfg.HTTP.RateLimit = &config.RateLimitConfig{
+		Rate:      &rate,
+		Burst:     &burst,
+		ExpiresIn: &expiresIn,
+	}
+	cfg.HTTP.SessionRateLimit = &config.RateLimitConfig{
+		Rate:      &rate,
+		Burst:     &burst,
+		ExpiresIn: &expiresIn,
+	}
+	userUC := &routerTestUserUsecase{}
+	e := newRouterTestEchoWithConfigAndUserUsecase(cfg, userUC)
+
+	loginRequest := newRouterTestRequest(http.MethodPost, "/auth/login", "")
+	loginRequest.RemoteAddr = "192.0.2.1:1000"
+	loginResponse := httptest.NewRecorder()
+	e.ServeHTTP(loginResponse, loginRequest)
+	assert.NotEqual(t, http.StatusTooManyRequests, loginResponse.Code)
+
+	refreshRequest := httptest.NewRequestWithContext(
+		context.Background(),
+		http.MethodPost,
+		"/auth/refresh",
+		strings.NewReader(`{"refresh_token":"`+testRefreshToken+`"}`),
+	)
+	refreshRequest.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	refreshRequest.RemoteAddr = "192.0.2.1:1000"
+	refreshResponse := httptest.NewRecorder()
+	e.ServeHTTP(refreshResponse, refreshRequest)
+
+	assert.NotEqual(t, http.StatusTooManyRequests, refreshResponse.Code)
+	assert.Equal(t, http.StatusOK, refreshResponse.Code)
+}
+
 func TestRouter_TestRoutesDisabledByDefault(t *testing.T) {
 	e := echo.New()
 	r := NewRouter(RouterParams{
@@ -319,6 +446,10 @@ func newRouterTestEcho() *echo.Echo {
 }
 
 func newRouterTestEchoWithConfig(cfg *config.Config) *echo.Echo {
+	return newRouterTestEchoWithConfigAndUserUsecase(cfg, &routerTestUserUsecase{})
+}
+
+func newRouterTestEchoWithConfigAndUserUsecase(cfg *config.Config, userUC usecase.UserUsecase) *echo.Echo {
 	userID := uuid.New()
 	tokenSvc := &routerTestTokenService{
 		claims: map[string]*service.Claims{
@@ -332,15 +463,21 @@ func newRouterTestEchoWithConfig(cfg *config.Config) *echo.Echo {
 				Roles:  []string{string(entity.RoleMerchant)},
 				Type:   service.TokenTypeAccess,
 			},
+			testRefreshToken: {
+				UserID: userID,
+				Type:   service.TokenTypeRefresh,
+			},
 		},
 	}
 
 	e := echo.New()
 	e.IPExtractor = apimiddleware.NewClientIPExtractor(cfg)
 	e.Validator = apivalidator.New()
+	e.Use(apimiddleware.CaptureRequestBodyForErrorLog)
 	authMiddleware := apimiddleware.NewAuthMiddleware(tokenSvc, cfg)
 	r := NewRouter(RouterParams{
 		UserHandler: handler.NewUserHandler(handler.UserHandlerParams{
+			UserUC:    userUC,
 			ProfileUC: &routerTestProfileUsecase{},
 			Logger:    slog.Default(),
 		}),


### PR DESCRIPTION
## Summary

- remove the implicit RateLimitConfig.Validate path wrapper
- add a separate session rate limit configuration with explicit validation paths
- key /auth/refresh and /auth/logout by validated refresh-token user IDs with IP fallback
- preserve request bodies and keep credential/OAuth routes IP-keyed

## Verification

- go build ./...
- go vet ./...
- go test -count=1 ./...
- golangci-lint run ./internal/... ./config/...
- four mutation tests passed after restoration

No k6 run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added separate rate limiting for session actions such as token refresh and logout.
  * Session limits can be configured with independent rate, burst, and expiration settings.
  * Session requests are limited per authenticated user, with client IP fallback when needed.

* **Bug Fixes**
  * Authentication rate limiting now applies only to credential and account-linking actions.
  * Improved validation and error reporting for authentication and session rate-limit settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->