### PR TITLE
chore: remove legacy root routes

### DIFF
--- a/internal/delivery/api/router/router.go
+++ b/internal/delivery/api/router/router.go
@@ -66,7 +66,6 @@ func (r *router) RegisterRoutes(e *echo.Echo) error {
 	if err := r.registerPublicRoutes(e); err != nil {
 		return err
 	}
-	r.registerAuthenticatedRootRoutes(e)
 	if err := r.registerAPIV1Routes(e); err != nil {
 		return err
 	}
@@ -114,21 +113,6 @@ func (r *router) registerPublicRoutes(e *echo.Echo) error {
 	}
 
 	return nil
-}
-
-func (r *router) registerAuthenticatedRootRoutes(e *echo.Echo) {
-	userGroup := e.Group("/user")
-	userGroup.Use(r.authMiddleware.Authenticate)
-	{
-		userGroup.GET("/profile", r.userHandler.GetProfile)
-	}
-
-	merchantGroup := e.Group("/merchant")
-	merchantGroup.Use(r.authMiddleware.Authenticate)
-	merchantGroup.Use(r.authMiddleware.RequireRole(entity.RoleMerchant))
-	{
-		// Reserved for non-versioned merchant-only routes.
-	}
 }
 
 func (r *router) registerAPIV1Routes(e *echo.Echo) error {

--- a/internal/delivery/api/router/router_test.go
+++ b/internal/delivery/api/router/router_test.go
@@ -275,20 +275,27 @@ func TestRouter_PublicMerchantSearchStillRequiresUserRole(t *testing.T) {
 	assert.Contains(t, rec.Body.String(), `"code":"FORBIDDEN"`)
 }
 
-func TestRouter_ProfileSupportsAPIV1AndLegacyRoutes(t *testing.T) {
+func TestRouter_ProfileSupportsAPIV1Route(t *testing.T) {
 	e := newRouterTestEcho()
 
-	for _, path := range []string{"/api/v1/user/profile", "/user/profile"} {
-		t.Run(path, func(t *testing.T) {
-			req := newRouterTestRequest(http.MethodGet, path, testUserToken)
-			rec := httptest.NewRecorder()
+	t.Run("api v1 route", func(t *testing.T) {
+		req := newRouterTestRequest(http.MethodGet, "/api/v1/user/profile", testUserToken)
+		rec := httptest.NewRecorder()
 
-			e.ServeHTTP(rec, req)
+		e.ServeHTTP(rec, req)
 
-			require.Equal(t, http.StatusOK, rec.Code)
-			assert.Contains(t, rec.Body.String(), `"email":"tester@example.com"`)
-		})
-	}
+		require.Equal(t, http.StatusOK, rec.Code)
+		assert.Contains(t, rec.Body.String(), `"email":"tester@example.com"`)
+	})
+
+	t.Run("legacy route is removed", func(t *testing.T) {
+		req := newRouterTestRequest(http.MethodGet, "/user/profile", testUserToken)
+		rec := httptest.NewRecorder()
+
+		e.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusNotFound, rec.Code)
+	})
 }
 
 func TestRouter_MerchantProfileUpdateRouteRequiresMerchantRole(t *testing.T) {

--- a/k6/README.md
+++ b/k6/README.md
@@ -55,7 +55,7 @@ working.
 1. Setup merchant account (register or reuse + login).
 2. Check `/health` and `/test/public`.
 3. Register/login/refresh user.
-4. `GET /user/profile` and `/test/auth`.
+4. `GET /api/v1/user/profile` and `/test/auth`.
 5. User location create/list/update/delete.
 6. Device register/list/health/update/deactivate.
 7. Subscription subscribe/list/unsubscribe.


### PR DESCRIPTION
## Summary

- Remove the non-versioned `/user` and empty `/merchant` authenticated root route groups.
- Keep `/api/v1/user/profile` as the supported profile endpoint and verify `/user/profile` returns 404.
- Update the k6 README to document `/api/v1/user/profile`.

## Validation

- `go build ./...`
- `go vet ./...`
- `go test -count=1 ./internal/delivery/...` (128 passed)
- `go test -count=1 ./...` (654 passed)
- `golangci-lint run ./internal/...`
- `gofmt -l` on the changed Go files
- `git diff --check`

## Deployment note

This is a breaking public API change. Deploy to dev first, and promote to production only after the frontend migration to `/api/v1/user/profile` is live. k6 was not run because the functional flow already uses the versioned route.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Breaking Changes**
  - Removed legacy non-versioned authenticated routes.
  - User profile access is now available through `/api/v1/user/profile`.
  - Requests to the former `/user/profile` endpoint now return `404 Not Found`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->