### PR TITLE
refactor: extract dry-run SQL harness

### DIFF
--- a/internal/infra/persistence/postgres/discovery_repository_test.go
+++ b/internal/infra/persistence/postgres/discovery_repository_test.go
@@ -2,17 +2,12 @@ package postgres
 
 import (
 	"context"
-	"strings"
 	"testing"
-	"time"
 
 	"radar/internal/domain/repository"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
-	"gorm.io/driver/postgres"
-	"gorm.io/gorm"
-	gormlogger "gorm.io/gorm/logger"
 )
 
 func TestDiscoveryRepository_SearchPublicMerchantsQuery_EnforcesPublicEligibility(t *testing.T) {
@@ -80,13 +75,7 @@ type dryRunDiscoveryRepository struct {
 func newDryRunDiscoveryRepository(t *testing.T) *dryRunDiscoveryRepository {
 	t.Helper()
 
-	sqlLogger := &captureSQLLogger{}
-	db, err := gorm.Open(postgres.New(postgres.Config{
-		DSN:                  "host=localhost user=test password=test dbname=test sslmode=disable",
-		PreferSimpleProtocol: true,
-	}), &gorm.Config{DryRun: true, DisableAutomaticPing: true, Logger: sqlLogger})
-	require.NoError(t, err)
-
+	db, sqlLogger := newDryRunDB(t)
 	repo, ok := NewDiscoveryRepository(db).(*discoveryRepository)
 	require.True(t, ok)
 
@@ -94,34 +83,7 @@ func newDryRunDiscoveryRepository(t *testing.T) *dryRunDiscoveryRepository {
 }
 
 func discoverySearchSQL(dryRun *dryRunDiscoveryRepository, filter repository.PublicMerchantSearchFilter) string {
-	dryRun.sqlLogger.queries = nil
-
-	_, _, _ = dryRun.repo.SearchPublicMerchants(context.Background(), &filter)
-
-	sql := strings.Join(dryRun.sqlLogger.queries, " ")
-	sql = strings.ReplaceAll(sql, `"`, "")
-
-	return strings.Join(strings.Fields(sql), " ")
-}
-
-type captureSQLLogger struct {
-	queries []string
-}
-
-func (capture *captureSQLLogger) LogMode(gormlogger.LogLevel) gormlogger.Interface {
-	return capture
-}
-
-func (*captureSQLLogger) Info(context.Context, string, ...any) {
-}
-
-func (*captureSQLLogger) Warn(context.Context, string, ...any) {
-}
-
-func (*captureSQLLogger) Error(context.Context, string, ...any) {
-}
-
-func (capture *captureSQLLogger) Trace(_ context.Context, _ time.Time, fc func() (string, int64), _ error) {
-	sql, _ := fc()
-	capture.queries = append(capture.queries, sql)
+	return capturedSQL(dryRun.sqlLogger, func() {
+		_, _, _ = dryRun.repo.SearchPublicMerchants(context.Background(), &filter)
+	})
 }

--- a/internal/infra/persistence/postgres/dryrun_sql_test.go
+++ b/internal/infra/persistence/postgres/dryrun_sql_test.go
@@ -1,0 +1,59 @@
+package postgres
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	gormlogger "gorm.io/gorm/logger"
+)
+
+type captureSQLLogger struct {
+	queries []string
+}
+
+func (capture *captureSQLLogger) LogMode(gormlogger.LogLevel) gormlogger.Interface {
+	return capture
+}
+
+func (*captureSQLLogger) Info(context.Context, string, ...any) {
+}
+
+func (*captureSQLLogger) Warn(context.Context, string, ...any) {
+}
+
+func (*captureSQLLogger) Error(context.Context, string, ...any) {
+}
+
+func (capture *captureSQLLogger) Trace(_ context.Context, _ time.Time, fc func() (string, int64), _ error) {
+	sql, _ := fc()
+	capture.queries = append(capture.queries, sql)
+}
+
+func newDryRunDB(t *testing.T) (*gorm.DB, *captureSQLLogger) {
+	t.Helper()
+
+	sqlLogger := &captureSQLLogger{}
+	db, err := gorm.Open(postgres.New(postgres.Config{
+		DSN:                  "host=localhost user=test password=test dbname=test sslmode=disable",
+		PreferSimpleProtocol: true,
+	}), &gorm.Config{DryRun: true, DisableAutomaticPing: true, Logger: sqlLogger})
+	require.NoError(t, err)
+
+	return db, sqlLogger
+}
+
+func capturedSQL(logger *captureSQLLogger, run func()) string {
+	logger.queries = nil
+
+	run()
+
+	sql := strings.Join(logger.queries, " ")
+	sql = strings.ReplaceAll(sql, `"`, "")
+
+	return strings.Join(strings.Fields(sql), " ")
+}

--- a/internal/infra/persistence/postgres/menu_repository_test.go
+++ b/internal/infra/persistence/postgres/menu_repository_test.go
@@ -2,15 +2,12 @@ package postgres
 
 import (
 	"context"
-	"strings"
 	"testing"
 
 	"radar/internal/domain/repository"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
-	"gorm.io/driver/postgres"
-	"gorm.io/gorm"
 )
 
 func TestMenuRepository_ListMenuItemsByMerchantQuery_UsesStableOrdering(t *testing.T) {
@@ -32,13 +29,7 @@ type dryRunMenuRepository struct {
 func newDryRunMenuRepository(t *testing.T) *dryRunMenuRepository {
 	t.Helper()
 
-	sqlLogger := &captureSQLLogger{}
-	db, err := gorm.Open(postgres.New(postgres.Config{
-		DSN:                  "host=localhost user=test password=test dbname=test sslmode=disable",
-		PreferSimpleProtocol: true,
-	}), &gorm.Config{DryRun: true, DisableAutomaticPing: true, Logger: sqlLogger})
-	require.NoError(t, err)
-
+	db, sqlLogger := newDryRunDB(t)
 	repo, ok := NewMenuRepository(db).(*menuRepository)
 	require.True(t, ok)
 
@@ -46,12 +37,7 @@ func newDryRunMenuRepository(t *testing.T) *dryRunMenuRepository {
 }
 
 func menuListSQL(dryRun *dryRunMenuRepository, filter repository.MenuItemListFilter) string {
-	dryRun.sqlLogger.queries = nil
-
-	_, _, _ = dryRun.repo.ListMenuItemsByMerchant(context.Background(), uuid.New(), filter)
-
-	sql := strings.Join(dryRun.sqlLogger.queries, " ")
-	sql = strings.ReplaceAll(sql, `"`, "")
-
-	return strings.Join(strings.Fields(sql), " ")
+	return capturedSQL(dryRun.sqlLogger, func() {
+		_, _, _ = dryRun.repo.ListMenuItemsByMerchant(context.Background(), uuid.New(), filter)
+	})
 }

--- a/internal/infra/persistence/postgres/notification_repository_test.go
+++ b/internal/infra/persistence/postgres/notification_repository_test.go
@@ -2,13 +2,10 @@ package postgres
 
 import (
 	"context"
-	"strings"
 	"testing"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
-	"gorm.io/driver/postgres"
-	"gorm.io/gorm"
 )
 
 func TestNotificationRepository_FindNotificationsByMerchantQuery_UsesStableOrdering(t *testing.T) {
@@ -27,13 +24,7 @@ type dryRunNotificationRepository struct {
 func newDryRunNotificationRepository(t *testing.T) *dryRunNotificationRepository {
 	t.Helper()
 
-	sqlLogger := &captureSQLLogger{}
-	db, err := gorm.Open(postgres.New(postgres.Config{
-		DSN:                  "host=localhost user=test password=test dbname=test sslmode=disable",
-		PreferSimpleProtocol: true,
-	}), &gorm.Config{DryRun: true, DisableAutomaticPing: true, Logger: sqlLogger})
-	require.NoError(t, err)
-
+	db, sqlLogger := newDryRunDB(t)
 	repo, ok := NewNotificationRepository(db).(*notificationRepository)
 	require.True(t, ok)
 
@@ -41,12 +32,7 @@ func newDryRunNotificationRepository(t *testing.T) *dryRunNotificationRepository
 }
 
 func notificationListSQL(dryRun *dryRunNotificationRepository, merchantID uuid.UUID, limit, offset int) string {
-	dryRun.sqlLogger.queries = nil
-
-	_, _ = dryRun.repo.FindNotificationsByMerchant(context.Background(), merchantID, limit, offset)
-
-	sql := strings.Join(dryRun.sqlLogger.queries, " ")
-	sql = strings.ReplaceAll(sql, `"`, "")
-
-	return strings.Join(strings.Fields(sql), " ")
+	return capturedSQL(dryRun.sqlLogger, func() {
+		_, _ = dryRun.repo.FindNotificationsByMerchant(context.Background(), merchantID, limit, offset)
+	})
 }


### PR DESCRIPTION
## Summary

- Extract the shared dry-run GORM SQL capture harness into a test-only helper.
- Keep the repository-specific wrappers and all existing assertions unchanged.
- No production code changes.

## Validation

- `go build ./...`
- `go vet ./...`
- `go test -count=1 ./internal/infra/persistence/postgres/...`
- `go test -count=1 ./...`
- `golangci-lint run ./internal/...`
- `gofmt -l`, formatter check, and `git diff --check`
- All three ordering mutations caused their corresponding tests to fail and were restored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added shared utilities for capturing and normalizing generated SQL in PostgreSQL repository tests.
  * Simplified database test setup across discovery, menu, and notification repository coverage.
  * Reduced duplicated test configuration and improved consistency of SQL comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->