### PR TITLE
refactor: simplify release automation and close its untested gaps

### DIFF
--- a/.github/scripts/release/not_found.sh
+++ b/.github/scripts/release/not_found.sh
@@ -1,24 +1,46 @@
 #!/usr/bin/env bash
 
-# Only a real gcloud NOT_FOUND status may authorize a create/publish fallback.
+# Recognising "this resource does not exist" is the one place where a wrong
+# answer is silently destructive: a false positive lets a create/publish
+# fallback run against a resource that is actually there but unreadable.
+#
+# Every matcher here therefore accepts only two things: a real gcloud
+# NOT_FOUND status token, or one complete, exactly observed error line. Whole
+# line fixed-string matching is what removes the need for a status denylist --
+# a PERMISSION_DENIED or UNAVAILABLE line simply is not equal to the expected
+# line, so it fails closed on its own.
+#
+# Every literal below was captured from gcloud on 2026-08-23 against project
+# radar-dev-491902 in asia-east1. The release workflow re-probes them on every
+# run (release.sh check-error-contract) so wording drift is caught before any
+# mutation instead of at the moment a resource is misjudged.
+
+# Surfaces that return a structured status: Artifact Registry when the
+# repository itself is absent, and Cloud Scheduler.
+#   ERROR: (gcloud.artifacts.docker.images.describe) NOT_FOUND: Requested entity was not found. ...
+#   ERROR: (gcloud.scheduler.jobs.describe) NOT_FOUND: Job not found. ...
 not_found_status() {
   grep -Eq '(^|[[:space:]])NOT_FOUND([:[:space:]]|$)' "$1"
 }
 
-# Any gcloud status code other than NOT_FOUND is a real error, never a missing
-# resource. Keep this list explicit: an unlisted code degrades to the
-# surface-specific wording check, not to a blanket accept.
-other_gcloud_status() {
-  grep -Eq '(^|[[:space:]])(PERMISSION_DENIED|UNAUTHENTICATED|INVALID_ARGUMENT|FAILED_PRECONDITION|RESOURCE_EXHAUSTED|UNAVAILABLE|INTERNAL|ABORTED|UNKNOWN)([:[:space:]]|$)' "$1"
-}
-
-# Artifact Registry reports a missing image with no status token. Its wording
-# carries no resource identity, so only the complete observed error line is
-# trusted; status-qualified variants fail closed. Other not-found renderings
-# must be observed before they are accepted. Observed 2026-08-17 (ci run
-# 32002042274):
+# Artifact Registry reports a missing tag or image inside an existing
+# repository with no status token at all:
 #   ERROR: (gcloud.artifacts.docker.images.describe) Image not found.
+# Further explanatory lines follow it; only this line is trusted.
 image_not_found() {
   not_found_status "$1" && return 0
-  grep -Eq '^ERROR: \(gcloud\.artifacts\.docker\.images\.describe\) Image not found\.$' "$1"
+  grep -Fxq 'ERROR: (gcloud.artifacts.docker.images.describe) Image not found.' "$1"
+}
+
+# Cloud Run also reports missing resources without a status token. The three
+# surfaces are not consistently punctuated -- jobs end in a period, services
+# and revisions do not -- so both renderings are accepted:
+#   ERROR: (gcloud.run.services.describe) Cannot find service [NAME]
+#   ERROR: (gcloud.run.jobs.describe) Cannot find job [NAME].
+#   ERROR: (gcloud.run.revisions.describe) Cannot find revision [NAME]
+cloud_run_not_found() {
+  local type=$1 name=$2 file=$3 line
+  not_found_status "${file}" && return 0
+  line="ERROR: (gcloud.run.${type}s.describe) Cannot find ${type} [${name}]"
+  grep -Fxq -e "${line}" -e "${line}." "${file}"
 }

--- a/.github/scripts/release/release.sh
+++ b/.github/scripts/release/release.sh
@@ -3,6 +3,11 @@
 # Repository-specific Cloud Run release operations. Configuration is supplied
 # by the trusted workflow through environment variables; there is intentionally
 # no generic option layer.
+#
+# Every step a release workflow performs lives here rather than inline in YAML,
+# so that it is reachable from release_test.sh. A workflow step should be a
+# call to one of the subcommands at the bottom of this file plus the GitHub
+# Actions that cannot be expressed in bash (authentication, buildx, attest).
 set -euo pipefail
 
 repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/../../.." && pwd)
@@ -12,10 +17,46 @@ source "${repo_root}/.github/scripts/release/not_found.sh"
 
 die() { printf 'release: %s\n' "$*" >&2; exit 1; }
 integrity_die() { printf 'release: %s\n' "$*" >&2; exit 3; }
+
+# gcloud writes the text the not-found matchers need to stderr, so every lookup
+# captures it to a scratch file. These three own that file's whole lifetime:
+# take one from new_error_file, and end every unclassified failure in one of
+# the two reporters so the diagnostics are surfaced and the file is dropped.
+new_error_file() { mktemp "${RUNNER_TEMP:-/tmp}/release-gcloud-error.XXXXXX"; }
+fail_with_error_file() {
+  local file=$1
+  shift
+  cat "${file}" >&2
+  rm -f "${file}"
+  die "$*"
+}
+integrity_fail_with_error_file() {
+  local file=$1
+  shift
+  cat "${file}" >&2
+  rm -f "${file}"
+  integrity_die "$*"
+}
 required() { for name in "$@"; do test -n "${!name:-}" || die "missing ${name}"; done; }
 is_sha() { printf '%s' "$1" | grep -Eq '^[0-9a-f]{40}$'; }
+
+# A pinned rollback is typed by hand, usually while something is broken, so an
+# abbreviated SHA is accepted and expanded here. This can only widen what may
+# be typed, never what may be deployed: git rejects both unknown and ambiguous
+# prefixes, and the expanded SHA still has to pass the ancestry, completeness,
+# and attestation checks. Image tags are always the full 40 characters, so
+# every consumer downstream sees the expanded form.
+resolve_requested_sha() {
+  local resolved
+  printf '%s' "${REQUESTED_SHA}" | grep -Eq '^[0-9a-f]{7,40}$' \
+    || die 'REQUESTED_SHA must be 7 to 40 hexadecimal characters'
+  resolved=$(git rev-parse --verify --quiet "${REQUESTED_SHA}^{commit}") \
+    || die "REQUESTED_SHA ${REQUESTED_SHA} is not a unique commit in this repository"
+  printf '%s\n' "${resolved}"
+}
 is_digest() { printf '%s' "$1" | grep -Eq '^[^@[:space:]]+@sha256:[0-9a-f]{64}$'; }
 safe_line() { case "$2" in *$'\r'*|*$'\n'*) die "$1 must not contain CR or LF" ;; esac; }
+owner_slug() { printf '%s' "${OWNER}" | tr '[:upper:]' '[:lower:]'; }
 repo_path() {
   local configured=$1 default=$2
   if [ -z "${configured}" ]; then
@@ -28,6 +69,8 @@ repo_path() {
   fi
 }
 targets_file() { repo_path "${TARGETS_FILE:-}" "${default_targets_file}"; }
+
+# Validated once by the dispatcher, not on every catalog read.
 validate_catalog() {
   test -f "$(targets_file)" || die 'missing target catalog'
   jq -e '
@@ -60,10 +103,7 @@ validate_catalog() {
     fi
   done < <(jq -r 'keys[]' "$(targets_file)")
 }
-target_names() {
-  validate_catalog
-  jq -r 'to_entries | sort_by(.value.order) | .[].key' "$(targets_file)"
-}
+target_names() { jq -r 'to_entries | sort_by(.value.order) | .[].key' "$(targets_file)"; }
 target_kind() { jq -er --arg target "$1" '.[$target].kind' "$(targets_file)"; }
 target_overlay() { jq -er --arg target "$1" '.[$target].overlay' "$(targets_file)"; }
 target_manifest() { jq -er --arg target "$1" '.[$target].manifest' "$(targets_file)"; }
@@ -87,6 +127,66 @@ impact_path_args() {
     '.github/workflows/release-cloud-run.yml'
 }
 
+# 0 = at least one of the given paths differs, 1 = none do. Any other git
+# failure is fatal: "git broke" must never be read as "nothing changed".
+paths_changed() {
+  local from=$1 to=$2 status
+  shift 2
+  test "$#" -gt 0 || die 'paths_changed requires at least one path'
+  git diff --quiet "${from}..${to}" -- "$@" && return 1
+  status=$?
+  [ "${status}" -eq 1 ] || die "git diff failed while comparing ${from}..${to}"
+  return 0
+}
+
+impact_changed() {
+  local path_args=()
+  while IFS= read -r path; do
+    path_args+=("${path}")
+  done < <(impact_path_args)
+  test "${#path_args[@]}" -gt 0 || die 'impact path manifest is empty'
+  paths_changed "$1" "$2" "${path_args[@]}"
+}
+
+# Whether a push to main has to publish new candidate images. A force push, or
+# a before-SHA that is no longer reachable, cannot be diffed against at all, so
+# publish a complete candidate instead of guessing that nothing changed.
+candidate_changes() {
+  required GITHUB_SHA
+  local candidate=true
+  if printf '%s' "${BEFORE_SHA:-}" | grep -Eq '^[0]{40}$' \
+    || ! git cat-file -e "${BEFORE_SHA:-}^{commit}" 2>/dev/null; then
+    printf '::notice::Force-push or missing before SHA: publishing a complete candidate.\n'
+  elif ! impact_changed "${BEFORE_SHA}" "${GITHUB_SHA}"; then
+    candidate=false
+  fi
+  {
+    printf 'candidate=%s\n' "${candidate}"
+    printf 'targets=%s\n' "$(jq -e -c 'keys | select(length > 0)' "$(targets_file)")"
+  } >> "${GITHUB_OUTPUT:-/dev/stdout}"
+}
+
+# gcloud must answer with a fully qualified digest under exactly the expected
+# repository. Anything else is an integrity failure, not a usable reference.
+assert_digest_under() {
+  local image expected_base=$2
+  image=$(printf '%s' "$1" | tr -d '\r\n')
+  { [ "${image%@*}" = "${expected_base}" ] && is_digest "${image}"; } \
+    || integrity_die "${image} is not an exact digest under ${expected_base}"
+  printf '%s\n' "${image}"
+}
+
+# Describe and validate in one call. Callers that already hold a describe
+# result must use assert_digest_under instead of describing a second time: the
+# resolver walks up to 50 commits across every target and a duplicate describe
+# doubles that traffic.
+resolved_digest() {
+  local ref=$1 project=$2 expected_base=$3 image
+  image=$(gcloud artifacts docker images describe "${ref}" \
+    --project="${project}" --format='value(image_summary.fully_qualified_digest)')
+  assert_digest_under "${image}" "${expected_base}"
+}
+
 verify_attestation() {
   image=$1 sha=$2
   attempt=1
@@ -105,48 +205,181 @@ verify_attestation() {
   done
 }
 
+# ---------------------------------------------------------------------------
+# Error contract
+# ---------------------------------------------------------------------------
+
+error_contract_probe='error-contract-probe-do-not-create'
+
+# not_found.sh recognises missing resources by exact gcloud error strings.
+# Re-probe those strings against the live API before a release mutates
+# anything, so wording drift fails here rather than being misread as a missing
+# resource at a point where that authorizes a create or a publish.
+check_error_contract() {
+  required PROJECT_ID REGION REGISTRY OWNER
+  local owner type ref
+  owner=$(owner_slug)
+  # Not local: the EXIT trap below runs after this function has returned.
+  probe_error=$(new_error_file)
+  trap 'rm -f "${probe_error:-}"' EXIT HUP INT TERM
+
+  for type in service job revision; do
+    if gcloud run "${type}s" describe "${error_contract_probe}" \
+      --project="${PROJECT_ID}" --region="${REGION}" --format=json >/dev/null 2>"${probe_error}"; then
+      die "error contract probe ${type} unexpectedly exists"
+    fi
+    cloud_run_not_found "${type}" "${error_contract_probe}" "${probe_error}" \
+      || fail_with_error_file "${probe_error}" \
+        "gcloud run ${type}s not-found wording changed; update not_found.sh before releasing"
+  done
+
+  ref="${REGISTRY}/${owner}/${error_contract_probe}:probe"
+  if gcloud artifacts docker images describe "${ref}" \
+    --project="${PROJECT_ID}" --format='value(image_summary.fully_qualified_digest)' \
+    >/dev/null 2>"${probe_error}"; then
+    die 'error contract probe image unexpectedly exists'
+  fi
+  image_not_found "${probe_error}" \
+    || fail_with_error_file "${probe_error}" \
+      'Artifact Registry not-found wording changed; update not_found.sh before releasing'
+  printf 'release: not-found error contract verified against live gcloud\n' >&2
+}
+
+# ---------------------------------------------------------------------------
+# Candidate publication
+# ---------------------------------------------------------------------------
+
+# Build to a run-scoped staging tag first. The immutable SHA tag is added only
+# after the digest has been attested and that attestation verified, because an
+# immutable tag cannot be removed: publishing it before attestation would turn
+# any interruption into a permanently unreleasable commit.
+stage_candidate() {
+  required OWNER TARGET RELEASE_SHA REGISTRY PROJECT_ID
+  is_sha "${RELEASE_SHA}" || die 'invalid RELEASE_SHA'
+  jq -e --arg target "${TARGET}" '.[$target] != null' "$(targets_file)" >/dev/null \
+    || die "unknown target ${TARGET}"
+  local owner built final_ref expected_base describe_error existing nonce staging_ref staged
+  owner=$(owner_slug)
+  expected_base="${REGISTRY}/${owner}/${TARGET}"
+  final_ref="${expected_base}:${RELEASE_SHA}"
+  built=$(git show -s --format=%cI "${RELEASE_SHA}")
+
+  describe_error=$(new_error_file)
+  if existing=$(gcloud artifacts docker images describe "${final_ref}" \
+    --project="${PROJECT_ID}" --format='value(image_summary.fully_qualified_digest)' \
+    2>"${describe_error}"); then
+    rm -f "${describe_error}"
+    existing=$(assert_digest_under "${existing}" "${expected_base}")
+    {
+      printf 'owner=%s\n' "${owner}"
+      printf 'digest=%s\n' "${existing##*@}"
+      printf 'staging_ref=\n'
+      printf 'needs_finalize=false\n'
+    } >> "${GITHUB_OUTPUT:-/dev/stdout}"
+    return 0
+  fi
+  image_not_found "${describe_error}" \
+    || fail_with_error_file "${describe_error}" "unable to inspect candidate image for ${TARGET}"
+  rm -f "${describe_error}"
+
+  nonce=$(openssl rand -hex 16)
+  staging_ref="${expected_base}:candidate-stage-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${nonce}-${TARGET}"
+  docker buildx build \
+    --file "${repo_root}/Dockerfile" \
+    --target "${TARGET}" \
+    --platform linux/amd64 \
+    --pull \
+    --provenance=false \
+    --sbom=false \
+    --build-arg "VERSION=${RELEASE_SHA}" \
+    --build-arg "BUILT=${built}" \
+    --build-arg "GIT_COMMIT=${RELEASE_SHA}" \
+    --build-arg "IMAGE_NAME=${owner}" \
+    --cache-from "type=gha,scope=${TARGET}" \
+    --cache-to "type=gha,mode=max,scope=${TARGET}" \
+    --tag "${staging_ref}" \
+    --push \
+    "${repo_root}"
+  staged=$(resolved_digest "${staging_ref}" "${PROJECT_ID}" "${expected_base}")
+  {
+    printf 'owner=%s\n' "${owner}"
+    printf 'digest=%s\n' "${staged##*@}"
+    printf 'staging_ref=%s\n' "${staging_ref}"
+    printf 'needs_finalize=true\n'
+  } >> "${GITHUB_OUTPUT:-/dev/stdout}"
+}
+
+# Add the immutable SHA tag to the already attested digest, prove the tag
+# resolves to exactly that digest, then drop the staging tag.
+finalize_candidate() {
+  required OWNER TARGET RELEASE_SHA REGISTRY PROJECT_ID STAGED_DIGEST NEEDS_FINALIZE
+  local owner expected_base final_ref final_digest
+  owner=$(owner_slug)
+  expected_base="${REGISTRY}/${owner}/${TARGET}"
+  final_ref="${expected_base}:${RELEASE_SHA}"
+  if [ "${NEEDS_FINALIZE}" = true ]; then
+    required STAGING_REF
+    gcloud artifacts docker tags add "${STAGING_REF%:*}@${STAGED_DIGEST}" "${final_ref}" \
+      --project="${PROJECT_ID}"
+  fi
+  final_digest=$(resolved_digest "${final_ref}" "${PROJECT_ID}" "${expected_base}")
+  [ "${final_digest##*@}" = "${STAGED_DIGEST}" ] \
+    || integrity_die "final candidate tag for ${TARGET} does not equal the attested digest"
+  if [ -n "${STAGING_REF:-}" ]; then
+    gcloud artifacts docker tags delete "${STAGING_REF}" \
+      --project="${PROJECT_ID}" --quiet \
+      || printf '::warning::Could not delete staging tag %s; immutable-tag repositories may retain it.\n' "${STAGING_REF}"
+  fi
+  {
+    echo '## Candidate image'
+    echo
+    echo "Release SHA: \`${RELEASE_SHA}\`"
+    echo
+    echo '| Target | Digest |'
+    echo '| --- | --- |'
+    echo "| ${TARGET} | \`${final_digest##*@}\` |"
+  } >> "${GITHUB_STEP_SUMMARY:-/dev/stdout}"
+}
+
+verify_candidate_attestation() {
+  required IMAGE RELEASE_SHA GITHUB_REPOSITORY
+  verify_attestation "${IMAGE}" "${RELEASE_SHA}" \
+    || die "attestation did not verify for ${IMAGE}"
+}
+
+# ---------------------------------------------------------------------------
+# Candidate resolution
+# ---------------------------------------------------------------------------
+
 resolve_candidate_image() {
   target=$1 sha=$2 owner=$3
-  tag="${DEV_REGISTRY}/${owner}/${target}:${sha}"
-  error_file=$(mktemp "${RUNNER_TEMP:-/tmp}/candidate-describe.XXXXXX")
-  if image=$(gcloud artifacts docker images describe "${tag}" \
-    --project="${DEV_PROJECT_ID}" --format='value(image_summary.fully_qualified_digest)' 2>"${error_file}"); then
+  expected_base="${DEV_REGISTRY}/${owner}/${target}"
+  error_file=$(new_error_file)
+  if image=$(gcloud artifacts docker images describe "${expected_base}:${sha}" \
+    --project="${DEV_PROJECT_ID}" --format='value(image_summary.fully_qualified_digest)' \
+    2>"${error_file}"); then
     rm -f "${error_file}"
   else
     if image_not_found "${error_file}"; then
       rm -f "${error_file}"
       return 1
     fi
-    cat "${error_file}" >&2
-    rm -f "${error_file}"
-    integrity_die "unable to inspect candidate image ${target}"
+    integrity_fail_with_error_file "${error_file}" "unable to inspect candidate image ${target}"
   fi
-  image=$(printf '%s' "${image}" | tr -d '\r\n')
-  expected_base="${DEV_REGISTRY}/${owner}/${target}"
-  if ! { [ "${image%@*}" = "${expected_base}" ] && is_digest "${image}"; }; then
-    integrity_die "candidate ${target} at ${sha} did not resolve to an exact dev digest"
-  fi
-  printf '%s\n' "${image}"
+  assert_digest_under "${image}" "${expected_base}"
 }
 
 resolve_candidate() {
   required CONTROL_SHA DEV_PROJECT_ID DEV_REGISTRY OWNER GITHUB_REPOSITORY
   is_sha "${CONTROL_SHA}" || die 'invalid CONTROL_SHA'
-  validate_catalog
   git cat-file -e "${CONTROL_SHA}^{commit}" || die 'CONTROL_SHA is not available locally'
-  owner=$(printf '%s' "${OWNER}" | tr '[:upper:]' '[:lower:]')
-  path_args=()
-  while IFS= read -r path; do
-    path_args+=("${path}")
-  done < <(impact_path_args)
-  test "${#path_args[@]}" -gt 0 || die 'impact path manifest is empty'
+  owner=$(owner_slug)
 
   if [ -n "${REQUESTED_SHA:-}" ]; then
-    is_sha "${REQUESTED_SHA}" || die 'invalid REQUESTED_SHA'
-    git cat-file -e "${REQUESTED_SHA}^{commit}" || die 'REQUESTED_SHA is not available locally'
-    git merge-base --is-ancestor "${REQUESTED_SHA}" "${CONTROL_SHA}" \
+    requested=$(resolve_requested_sha)
+    git merge-base --is-ancestor "${requested}" "${CONTROL_SHA}" \
       || die 'REQUESTED_SHA is not an ancestor of the current main control commit'
-    candidates="${REQUESTED_SHA}"
+    candidates="${requested}"
   else
     candidates=$(git rev-list --first-parent --max-count=50 "${CONTROL_SHA}") \
       || die "git rev-list failed while scanning candidates"
@@ -155,14 +388,8 @@ resolve_candidate() {
   while IFS= read -r candidate <&3; do
     # A candidate can only be promoted when everything after it is outside the
     # release contract. This is what permits docs-only commits without rebuilds.
-    if [ -z "${REQUESTED_SHA:-}" ]; then
-      if git diff --quiet "${candidate}..${CONTROL_SHA}" -- "${path_args[@]}"; then
-        :
-      else
-        diff_status=$?
-        [ "${diff_status}" -eq 1 ] || die "git diff failed while scanning candidate ${candidate}"
-        continue
-      fi
+    if [ -z "${REQUESTED_SHA:-}" ] && impact_changed "${candidate}" "${CONTROL_SHA}"; then
+      continue
     fi
     images='{}'
     complete=true
@@ -210,25 +437,25 @@ validate_bundle() {
   ' "${BUNDLE_FILE}" >/dev/null || die 'invalid release bundle'
 }
 
-not_found() {
-  not_found_status "$3" && return 0
-  # Cloud Run renders not-found without a status token. Explicitly reject
-  # other gcloud status codes before accepting its resource-specific wording.
-  other_gcloud_status "$3" && return 1
-  grep -Fqi "Cannot find $1 [$2]" "$3"
-}
+# ---------------------------------------------------------------------------
+# Cloud Run state
+# ---------------------------------------------------------------------------
 
+# Each field below is read from the one JSON path gcloud actually populates,
+# verified against live dev resources on 2026-08-23. A missing image means the
+# response shape changed and must be treated as an error, never as an empty
+# string that would compare unequal and silently look like drift.
 describe_resource() {
   type=$1 name=$2
-  error_file=$(mktemp "${RUNNER_TEMP:-/tmp}/release-error.XXXXXX")
+  error_file=$(new_error_file)
   if [ "${type}" = service ]; then
     if ! json=$(gcloud run services describe "${name}" --project="${PROJECT_ID}" --region="${REGION}" --format=json 2>"${error_file}"); then
-      if not_found "${type}" "${name}" "${error_file}"; then
+      if cloud_run_not_found "${type}" "${name}" "${error_file}"; then
         rm -f "${error_file}"
         jq -cn '{exists:false,label:"",desired_label:"",ready:false,image:""}'
         return
       fi
-      cat "${error_file}" >&2; rm -f "${error_file}"; die "cannot describe ${name}"
+      fail_with_error_file "${error_file}" "cannot describe ${name}"
     fi
     rm -f "${error_file}"
     desired=$(jq -r '.metadata.labels["release-sha"] // ""' <<<"${json}")
@@ -236,19 +463,18 @@ describe_resource() {
     ready=$(jq -r '([.status.conditions[]? | select(.type == "Ready") | .status] | first) // "False"' <<<"${json}")
     label='' image=''
     if [ -n "${revision}" ]; then
-      revision_error=$(mktemp "${RUNNER_TEMP:-/tmp}/release-revision.XXXXXX")
+      revision_error=$(new_error_file)
       if revision_json=$(gcloud run revisions describe "${revision}" \
         --project="${PROJECT_ID}" --region="${REGION}" --format=json 2>"${revision_error}"); then
         rm -f "${revision_error}"
-        label=$(jq -r '.metadata.labels["release-sha"] // .spec.template.metadata.labels["release-sha"] // ""' <<<"${revision_json}")
-        image=$(jq -r '.spec.containers[0].image // .spec.template.spec.containers[0].image // ""' <<<"${revision_json}")
-      elif not_found revision "${revision}" "${revision_error}"; then
+        label=$(jq -r '.metadata.labels["release-sha"] // ""' <<<"${revision_json}")
+        image=$(jq -er '.spec.containers[0].image' <<<"${revision_json}") \
+          || die "revision ${revision} response has no container image"
+      elif cloud_run_not_found revision "${revision}" "${revision_error}"; then
         rm -f "${revision_error}"
         ready=False
       else
-        cat "${revision_error}" >&2
-        rm -f "${revision_error}"
-        die "cannot describe revision ${revision}"
+        fail_with_error_file "${revision_error}" "cannot describe revision ${revision}"
       fi
     fi
     [ "${ready}" = True ] && ready=true || ready=false
@@ -256,15 +482,21 @@ describe_resource() {
       '{exists:true,label:$label,desired_label:$desired,ready:$ready,image:$image}'
   else
     if ! json=$(gcloud run jobs describe "${name}" --project="${PROJECT_ID}" --region="${REGION}" --format=json 2>"${error_file}"); then
-      if not_found "${type}" "${name}" "${error_file}"; then
+      if cloud_run_not_found "${type}" "${name}" "${error_file}"; then
         rm -f "${error_file}"
         jq -cn '{exists:false,label:"",desired_label:"",ready:true,image:""}'
         return
       fi
-      cat "${error_file}" >&2; rm -f "${error_file}"; die "cannot describe ${name}"
+      fail_with_error_file "${error_file}" "cannot describe ${name}"
     fi
     rm -f "${error_file}"
-    jq -c '{exists:true,label:(.metadata.labels["release-sha"] // ""),desired_label:"",ready:true,image:(.spec.template.spec.template.spec.containers[0].image // .spec.template.template.spec.containers[0].image // .spec.template.spec.containers[0].image // "")}' <<<"${json}"
+    # jq -e only inspects the last output value, so wrapping this in an object
+    # would report success with a null image. Extract it on its own.
+    label=$(jq -r '.metadata.labels["release-sha"] // ""' <<<"${json}")
+    image=$(jq -er '.spec.template.spec.template.spec.containers[0].image' <<<"${json}") \
+      || die "job ${name} response has no container image"
+    jq -cn --arg label "${label}" --arg image "${image}" \
+      '{exists:true,label:$label,desired_label:"",ready:true,image:$image}'
   fi
 }
 
@@ -297,7 +529,7 @@ baseline_digest() {
     return
   fi
   required REGISTRY OWNER PROJECT_ID
-  owner=$(printf '%s' "${OWNER}" | tr '[:upper:]' '[:lower:]')
+  owner=$(owner_slug)
   gcloud artifacts docker images describe "${REGISTRY}/${owner}/${target}:${label}" \
     --project="${PROJECT_ID}" --format='value(image_summary.fully_qualified_digest)'
 }
@@ -320,7 +552,10 @@ preflight() {
   is_sha "${RELEASE_SHA}" || die 'invalid RELEASE_SHA'
   if [ -n "${REQUESTED_SHA:-}" ]; then
     required CONTROL_SHA
-    [ "${REQUESTED_SHA}" = "${RELEASE_SHA}" ] || die 'pinned release SHA does not match REQUESTED_SHA'
+    # Compare against the expanded form: the resolver already turned an
+    # abbreviated pin into the full SHA that RELEASE_SHA carries.
+    [ "$(resolve_requested_sha)" = "${RELEASE_SHA}" ] \
+      || die 'pinned release SHA does not match REQUESTED_SHA'
   fi
   validate_bundle
   state=$(snapshot) || die 'cannot snapshot Cloud Run state'
@@ -330,8 +565,8 @@ preflight() {
     <<<"${state}" >/dev/null || die 'invalid Cloud Run state'
 
   # Desired service labels must never disagree with their ready revisions.
-  jq -e --arg target "${RELEASE_SHA}" \
-    'all(.[]; (.desired_label // "") == "" or .desired_label == .label or .desired_label == $target)' \
+  jq -e --arg release_sha "${RELEASE_SHA}" \
+    'all(.[]; (.desired_label // "") == "" or .desired_label == .label or .desired_label == $release_sha)' \
     <<<"${state}" >/dev/null \
     || die 'Cloud Run desired/running label drift'
   while IFS= read -r label; do
@@ -346,7 +581,7 @@ preflight() {
       required REGISTRY OWNER
       expected=$(jq -r --arg target "${target}" '.images[$target]' "${BUNDLE_FILE}")
       is_digest "${image}" || die "target-labelled ${target} image is not immutable"
-      owner=$(printf '%s' "${OWNER}" | tr '[:upper:]' '[:lower:]')
+      owner=$(owner_slug)
       [ "${image%@*}" = "${REGISTRY}/${owner}/${target}" ] \
         || die "target-labelled ${target} image is outside the current environment registry"
       [ "${image##*@}" = "${expected##*@}" ] \
@@ -377,8 +612,8 @@ preflight() {
       baseline_is_compatible "${baseline}" \
         || die "release is not compatible with the current target baseline ${baseline}"
     fi
-  elif [ "${count}" -eq 2 ] && jq -e --arg target "${RELEASE_SHA}" 'index($target) != null' <<<"${labels}" >/dev/null; then
-    baseline=$(jq -r --arg target "${RELEASE_SHA}" '.[] | select(. != $target)' <<<"${labels}")
+  elif [ "${count}" -eq 2 ] && jq -e --arg release_sha "${RELEASE_SHA}" 'index($release_sha) != null' <<<"${labels}" >/dev/null; then
+    baseline=$(jq -r --arg release_sha "${RELEASE_SHA}" '.[] | select(. != $release_sha)' <<<"${labels}")
     baseline_is_compatible "${baseline}" \
       || die "release is not compatible with the partial target baseline ${baseline}"
   else
@@ -391,6 +626,93 @@ preflight() {
     printf 'baseline_sha=%s\n' "${baseline}" >> "${GITHUB_OUTPUT}"
   fi
 }
+
+# ---------------------------------------------------------------------------
+# Migrations
+# ---------------------------------------------------------------------------
+
+# Which goose phases the release must run, derived from what changed between
+# the fleet baseline and the selected candidate.
+migration_phases() {
+  required RELEASE_SHA
+  local pre=false shared=false post=false any=false
+
+  if [ -n "${REQUESTED_SHA:-}" ]; then
+    # A pinned release moves code without moving schema, and the schema is
+    # forward-only. If the pin does not sit on the same side of every
+    # migration change as the running baseline, deploying it would run old
+    # code against a schema it has never seen. Stop and make that explicit
+    # rather than reporting it in a notice nobody reads.
+    if [ -n "${BASELINE_SHA:-}" ] && [ "${BASELINE_SHA}" != "${RELEASE_SHA}" ] \
+      && paths_changed "${RELEASE_SHA}" "${BASELINE_SHA}" 'database/migration/**'; then
+      test "${ACKNOWLEDGE_SCHEMA_DRIFT:-false}" = true || die \
+        "pinned release ${RELEASE_SHA} crosses a migration change against baseline ${BASELINE_SHA}; handle the schema first, then re-dispatch with acknowledge_schema_drift"
+      printf '::warning::Pinned release crosses a migration change; proceeding on explicit acknowledgement.\n'
+    fi
+    printf 'pre=false\nshared=false\npost=false\nany=false\n' >> "${GITHUB_OUTPUT:-/dev/stdout}"
+    printf '::notice::Pinned release: migrations skipped. Handle schema separately.\n'
+    return 0
+  fi
+
+  if [ -z "${BASELINE_SHA:-}" ]; then
+    pre=true shared=true post=true
+  elif [ "${BASELINE_SHA}" != "${RELEASE_SHA}" ]; then
+    paths_changed "${BASELINE_SHA}" "${RELEASE_SHA}" 'database/migration/supabase/pre' && pre=true
+    paths_changed "${BASELINE_SHA}" "${RELEASE_SHA}" 'database/migration/postgres' && shared=true
+    paths_changed "${BASELINE_SHA}" "${RELEASE_SHA}" 'database/migration/supabase/post' && post=true
+  fi
+  { [ "${pre}" = false ] && [ "${shared}" = false ] && [ "${post}" = false ]; } || any=true
+  printf 'pre=%s\nshared=%s\npost=%s\nany=%s\n' \
+    "${pre}" "${shared}" "${post}" "${any}" >> "${GITHUB_OUTPUT:-/dev/stdout}"
+}
+
+# ---------------------------------------------------------------------------
+# Promotion
+# ---------------------------------------------------------------------------
+
+# Copy the exact dev digests into the prod registry without rebuilding. An
+# existing prod tag is accepted only when it already points at the same digest.
+promote() {
+  required SOURCE_BUNDLE RELEASE_SHA OWNER REGISTRY PROJECT_ID GCRANE
+  test -x "${GCRANE}" || die 'pinned gcrane is not executable'
+  local owner promoted target source destination expected_base describe_error existing image bundle
+  owner=$(owner_slug)
+  promoted='{}'
+  while IFS= read -r target; do
+    # Preflight has already validated the complete target set and pinned digests.
+    source=$(jq -er --arg target "${target}" '.images[$target]' "${SOURCE_BUNDLE}") \
+      || die "source bundle has no image for ${target}"
+    expected_base="${REGISTRY}/${owner}/${target}"
+    destination="${expected_base}:${RELEASE_SHA}"
+    describe_error=$(new_error_file)
+    if existing=$(gcloud artifacts docker images describe "${destination}" \
+      --project="${PROJECT_ID}" --format='value(image_summary.fully_qualified_digest)' 2>"${describe_error}"); then
+      rm -f "${describe_error}"
+      image=$(assert_digest_under "${existing}" "${expected_base}")
+      [ "${image##*@}" = "${source##*@}" ] \
+        || integrity_die "immutable prod tag already points to a different digest: ${target}"
+    else
+      # Only a genuine missing image may authorize a copy. Any other failure,
+      # a permission error in particular, must not be read as "not there yet".
+      image_not_found "${describe_error}" \
+        || fail_with_error_file "${describe_error}" "unable to inspect prod image: ${target}"
+      rm -f "${describe_error}"
+      "${GCRANE}" copy "${source}" "${destination}"
+      image=$(resolved_digest "${destination}" "${PROJECT_ID}" "${expected_base}")
+      [ "${image##*@}" = "${source##*@}" ] \
+        || integrity_die "prod digest verification failed: ${target}"
+    fi
+    promoted=$(jq -c --arg target "${target}" --arg image "${image}" '. + {($target):$image}' <<<"${promoted}")
+  done < <(target_names)
+  bundle="${RUNNER_TEMP:-/tmp}/promoted-bundle.json"
+  jq -cn --arg sha "${RELEASE_SHA}" --argjson images "${promoted}" \
+    '{release_sha:$sha,images:$images}' > "${bundle}"
+  printf 'path=%s\n' "${bundle}" >> "${GITHUB_OUTPUT:-/dev/stdout}"
+}
+
+# ---------------------------------------------------------------------------
+# Deployment
+# ---------------------------------------------------------------------------
 
 replace_placeholder() {
   local placeholder=$1 value=$2
@@ -453,7 +775,6 @@ deploy() {
     required CLOUDFLARE_ORIGIN_SECRET
     safe_line CLOUDFLARE_ORIGIN_SECRET "${CLOUDFLARE_ORIGIN_SECRET}"
   fi
-  validate_catalog
   validate_bundle
   if jq -e 'any(.[]; .kind == "job")' "$(targets_file)" >/dev/null; then
     required PROJECT_NUMBER
@@ -466,12 +787,11 @@ deploy() {
     image=$(jq -r --arg target "${target}" '.images[$target]' "${BUNDLE_FILE}")
     is_digest "${image}" || die "bundle contains a mutable image for ${target}"
     kind=$(target_kind "${target}")
+    manifest_file="${temp_dir}/${target}.yaml"
     if [ "${kind}" = service ]; then
-      manifest_file="${temp_dir}/${target}.yaml"
       render_service "${target}" "${image}" "${manifest_file}"
       gcloud run services replace "${manifest_file}" --project="${PROJECT_ID}" --region="${REGION}" --quiet
     else
-      manifest_file="${temp_dir}/${target}.yaml"
       render_job "${target}" "${image}" "${manifest_file}"
       gcloud run jobs replace "${manifest_file}" --project="${PROJECT_ID}" --region="${REGION}" --quiet
     fi
@@ -513,11 +833,28 @@ verify() {
   fi
 }
 
-case "${1:-}" in
+# === dispatch ===
+# release_test.sh sources everything above this marker to exercise individual
+# functions. Keep the marker line exactly as written.
+command=${1:-}
+# The catalog is the input to almost every subcommand, so validate it once here
+# rather than on each of the dozen catalog reads a single release performs.
+case "${command}" in
+  impact-paths|check-error-contract) ;;
+  *) validate_catalog ;;
+esac
+case "${command}" in
   impact-paths) impact_path_args ;;
+  check-error-contract) check_error_contract ;;
+  candidate-changes) candidate_changes ;;
+  stage-candidate) stage_candidate ;;
+  verify-attestation) verify_candidate_attestation ;;
+  finalize-candidate) finalize_candidate ;;
   resolve-candidate) resolve_candidate ;;
   preflight) preflight ;;
+  migration-phases) migration_phases ;;
+  promote) promote ;;
   deploy) deploy ;;
   verify) verify ;;
-  *) die 'usage: release.sh impact-paths|resolve-candidate|preflight|deploy|verify' ;;
+  *) die 'usage: release.sh impact-paths|check-error-contract|candidate-changes|stage-candidate|verify-attestation|finalize-candidate|resolve-candidate|preflight|migration-phases|promote|deploy|verify' ;;
 esac

--- a/.github/scripts/release/release_test.sh
+++ b/.github/scripts/release/release_test.sh
@@ -324,6 +324,16 @@ if [ -n "${MOCK_DESCRIBE_ERROR_TARGET:-}" ] \
     "${2}" "${4}" >&2
   exit 1
 fi
+if [ -n "${MOCK_NO_IMAGE_TARGET:-}" ]; then
+  case "$*" in
+    "run jobs describe ${MOCK_NO_IMAGE_TARGET} "*)
+      jq -cn --arg sha "${MOCK_SHA}" '{metadata:{labels:{"release-sha":$sha}},spec:{template:{spec:{template:{spec:{containers:[{}]}}}}}}'
+      exit 0 ;;
+    "run revisions describe ${MOCK_NO_IMAGE_TARGET} "*)
+      jq -cn --arg sha "${MOCK_SHA}" '{metadata:{labels:{"release-sha":$sha}},spec:{containers:[{}]}}'
+      exit 0 ;;
+  esac
+fi
 case "$*" in
   'run services describe radar '*'--format=json'*)
     jq -cn --arg sha "${MOCK_SHA}" '{metadata:{labels:{"release-sha":$sha}},status:{latestReadyRevisionName:"radar-ready",conditions:[{type:"Ready",status:"True"}]}}'
@@ -370,6 +380,19 @@ assert_missing_cloud_run_target() {
 assert_missing_cloud_run_target device-cleanup
 assert_missing_cloud_run_target geoworker
 
+# A describe that answers without a container image is a response-shape change,
+# not a resource running an empty image. Snapshotting it must fail rather than
+# emit a null that only surfaces later as a confusing digest mismatch.
+for no_image_target in device-cleanup radar-ready; do
+  if (
+    cd "${git_dir}"
+    env "${common_env[@]}" MOCK_SHA="${sha}" MOCK_RADAR="${digest_a}" MOCK_GEOWORKER="${digest_b}" MOCK_CLEANUP="${digest_c}" \
+      MOCK_NO_IMAGE_TARGET="${no_image_target}" \
+      bash -c 'source "$1"; snapshot' "${script_dir}/release.sh" "${release_functions}"
+  ) >/dev/null 2>&1; then
+    fail "snapshot-accepted-missing-image-${no_image_target}"
+  fi
+done
 describe_error_output="${temp_dir}/describe-error-preflight.txt"
 if env "${common_env[@]}" MOCK_SHA="${sha}" MOCK_RADAR="${digest_a}" MOCK_GEOWORKER="${digest_b}" MOCK_CLEANUP="${digest_c}" \
   MOCK_DESCRIBE_ERROR_TARGET=device-cleanup \
@@ -552,6 +575,28 @@ if run_resolver "${resolver_control}" "${temp_dir}/resolver-pin-non-ancestor-env
 fi
 grep -F 'not an ancestor' "${resolver_pin_non_ancestor_output}" >/dev/null \
   || fail resolver-pin-non-ancestor-message
+# A pin may be abbreviated, because it is typed by hand during a rollback. The
+# resolver must expand it to the full SHA the image tags actually use.
+resolver_short=$(git -C "${resolver_dir}" rev-parse --short=8 "${resolver_candidate}")
+resolver_short_output="${temp_dir}/resolver-short-output"
+run_resolver "${resolver_control}" "${resolver_short_output}" "${resolver_short}"
+grep -Fx "release_sha=${resolver_candidate}" "${resolver_short_output}" >/dev/null \
+  || fail resolver-pin-short-sha-expansion
+# Too short to be meaningful.
+if run_resolver "${resolver_control}" "${temp_dir}/resolver-pin-tiny-env" "$(printf '%s' "${resolver_candidate}" | cut -c1-4)" \
+  >/dev/null 2>&1; then
+  fail resolver-pin-too-short-accepted
+fi
+# A prefix that matches no commit must fail rather than resolve to anything.
+if run_resolver "${resolver_control}" "${temp_dir}/resolver-pin-unknown-env" deadbeef \
+  >/dev/null 2>&1; then
+  fail resolver-pin-unknown-prefix-accepted
+fi
+# Non-hex input must never reach git.
+if run_resolver "${resolver_control}" "${temp_dir}/resolver-pin-ref-env" HEAD \
+  >/dev/null 2>&1; then
+  fail resolver-pin-ref-name-accepted
+fi
 
 resolver_pin_incomplete_output="${temp_dir}/resolver-pin-incomplete-output"
 if run_resolver "${resolver_control}" "${temp_dir}/resolver-pin-incomplete-env" "${resolver_candidate}" device-cleanup \
@@ -705,7 +750,104 @@ if (
   fail empty-catalog-guard
 fi
 
+# --- candidate change detection -------------------------------------------
+# A push that touches nothing in the release contract must not republish, and
+# a push that cannot be diffed at all must republish rather than assume.
+changes_dir="${temp_dir}/changes-git"
+git init -q "${changes_dir}"
+git -C "${changes_dir}" config user.email test@example.invalid
+git -C "${changes_dir}" config user.name 'Release Changes Test'
+git -C "${changes_dir}" commit -q --allow-empty -m base
+changes_base=$(git -C "${changes_dir}" rev-parse HEAD)
+mkdir -p "${changes_dir}/docs"
+printf 'docs\n' > "${changes_dir}/docs/note.md"
+git -C "${changes_dir}" add docs/note.md
+git -C "${changes_dir}" commit -q -m docs-only
+changes_docs=$(git -C "${changes_dir}" rev-parse HEAD)
+mkdir -p "${changes_dir}/internal"
+printf 'code\n' > "${changes_dir}/internal/app.go"
+git -C "${changes_dir}" add internal/app.go
+git -C "${changes_dir}" commit -q -m code
+changes_code=$(git -C "${changes_dir}" rev-parse HEAD)
 
+run_changes() {
+  local before=$1 head=$2 catalog=${3:-${repo_root}/.github/scripts/release/targets.json}
+  (
+    cd "${changes_dir}"
+    BEFORE_SHA="${before}" GITHUB_SHA="${head}" TARGETS_FILE="${catalog}" \
+      GITHUB_OUTPUT=/dev/stdout bash "${script_dir}/release.sh" candidate-changes
+  )
+}
+run_changes "${changes_base}" "${changes_docs}" | grep -Fx 'candidate=false' >/dev/null \
+  || fail changes-docs-only-republished
+run_changes "${changes_docs}" "${changes_code}" | grep -Fx 'candidate=true' >/dev/null \
+  || fail changes-code-not-detected
+run_changes "$(printf '0%.0s' {1..40})" "${changes_code}" | grep -Fx 'candidate=true' >/dev/null \
+  || fail changes-force-push-not-republished
+run_changes "$(printf 'f%.0s' {1..40})" "${changes_code}" | grep -Fx 'candidate=true' >/dev/null \
+  || fail changes-unreachable-before-not-republished
+if run_changes "${changes_base}" "${changes_docs}" "${empty_catalog}" >/dev/null 2>&1; then
+  fail changes-empty-catalog-guard
+fi
+
+# --- migration phase selection --------------------------------------------
+migration_dir="${temp_dir}/migration-git"
+git init -q "${migration_dir}"
+git -C "${migration_dir}" config user.email test@example.invalid
+git -C "${migration_dir}" config user.name 'Release Migration Test'
+mkdir -p "${migration_dir}/database/migration/postgres" \
+  "${migration_dir}/database/migration/supabase/pre" \
+  "${migration_dir}/database/migration/supabase/post"
+printf 'base\n' > "${migration_dir}/database/migration/postgres/0001.sql"
+git -C "${migration_dir}" add -A
+git -C "${migration_dir}" commit -q -m base
+migration_base=$(git -C "${migration_dir}" rev-parse HEAD)
+printf 'pre\n' > "${migration_dir}/database/migration/supabase/pre/0001.sql"
+git -C "${migration_dir}" add -A
+git -C "${migration_dir}" commit -q -m schema
+migration_schema=$(git -C "${migration_dir}" rev-parse HEAD)
+printf 'docs\n' > "${migration_dir}/README.md"
+git -C "${migration_dir}" add -A
+git -C "${migration_dir}" commit -q -m docs
+migration_docs=$(git -C "${migration_dir}" rev-parse HEAD)
+
+run_migrations() {
+  local release=$1 baseline=$2 requested=${3:-} ack=${4:-false}
+  (
+    cd "${migration_dir}"
+    RELEASE_SHA="${release}" BASELINE_SHA="${baseline}" REQUESTED_SHA="${requested}" \
+      ACKNOWLEDGE_SCHEMA_DRIFT="${ack}" GITHUB_OUTPUT=/dev/stdout \
+      bash "${script_dir}/release.sh" migration-phases
+  )
+}
+# No baseline at all: bootstrap must check every phase.
+run_migrations "${migration_schema}" '' | grep -Fx 'any=true' >/dev/null \
+  || fail migrations-bootstrap
+# Nothing moved.
+run_migrations "${migration_schema}" "${migration_schema}" | grep -Fx 'any=false' >/dev/null \
+  || fail migrations-same-sha
+# Only the pre directory changed between baseline and release.
+migration_out=$(run_migrations "${migration_schema}" "${migration_base}")
+printf '%s\n' "${migration_out}" | grep -Fx 'pre=true' >/dev/null || fail migrations-pre
+printf '%s\n' "${migration_out}" | grep -Fx 'shared=false' >/dev/null || fail migrations-shared-false
+# A docs-only advance must not select any phase.
+run_migrations "${migration_docs}" "${migration_schema}" | grep -Fx 'any=false' >/dev/null \
+  || fail migrations-docs-only
+# A pinned release that does not cross a migration change is allowed through.
+run_migrations "${migration_docs}" "${migration_schema}" "${migration_docs}" \
+  | grep -Fx 'any=false' >/dev/null || fail migrations-pinned-clean
+# A pinned release that moves back across a migration change must stop: the
+# schema is forward-only, so this would run old code against a newer schema.
+pinned_drift_output="${temp_dir}/pinned-drift.txt"
+if run_migrations "${migration_base}" "${migration_schema}" "${migration_base}" \
+  >"${pinned_drift_output}" 2>&1; then
+  fail migrations-pinned-drift-allowed
+fi
+grep -F 'crosses a migration change' "${pinned_drift_output}" >/dev/null \
+  || fail migrations-pinned-drift-message
+# ...and must proceed once that is explicitly acknowledged.
+run_migrations "${migration_base}" "${migration_schema}" "${migration_base}" true \
+  | grep -Fx 'any=false' >/dev/null || fail migrations-pinned-drift-acknowledged
 
 goose_version=$(make -C "${repo_root}" -s --no-print-directory print-goose-version)
 printf '%s\n' "${goose_version}" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$' || fail goose-version-format

--- a/.github/scripts/release/release_test.sh
+++ b/.github/scripts/release/release_test.sh
@@ -31,36 +31,46 @@ if not_found_status "${status_fixture}"; then
   fail invalid-argument-not-not-found
 fi
 
+# Every literal below was captured from gcloud on 2026-08-23 (project
+# radar-dev-491902, asia-east1) by describing resources that do not exist.
+# These fixtures can only prove that the matchers still read the strings the
+# way they did then; they cannot notice gcloud changing its wording. That is
+# what `release.sh check-error-contract` does against the live API on every
+# release, and these cases exist to keep the parsing honest in between.
 image_fixture="${temp_dir}/image-not-found.txt"
-# Command: gcloud artifacts docker images describe <image-ref>
-# Source: Go CI run 32002042274, observed 2026-08-17.
 printf 'ERROR: (gcloud.artifacts.docker.images.describe) Image not found.\n' > "${image_fixture}"
-image_not_found "${image_fixture}" || fail image-not-found-real-ar
+image_not_found "${image_fixture}" || fail image-not-found-observed
 
-# Command: gcloud artifacts docker images describe <image-ref>
-# Source: synthetic NOT_FOUND status-contract fixture; no production capture claimed.
-printf 'ERROR: (gcloud.artifacts.docker.images.describe) NOT_FOUND: requested image was not found.\n' > "${image_fixture}"
+# A missing repository, as opposed to a missing tag, answers with a status.
+printf 'ERROR: (gcloud.artifacts.docker.images.describe) NOT_FOUND: Requested entity was not found.\n' > "${image_fixture}"
 image_not_found "${image_fixture}" || fail image-not-found-status
 
-# Command: gcloud artifacts docker images describe <image-ref>
-# Source: synthetic status-collision fixture; no production capture claimed.
+# Whole-line matching is the reason no status denylist is needed: a failure
+# that merely contains the not-found wording is not the not-found line.
 printf 'ERROR: (gcloud.artifacts.docker.images.describe) PERMISSION_DENIED: Image not found.\n' > "${image_fixture}"
 if image_not_found "${image_fixture}"; then
-  fail image-not-found-permission-collision
+  fail image-not-found-status-collision
 fi
 
-# Command: gcloud artifacts docker images describe <image-ref>
-# Source: synthetic permission-error fixture; no production capture claimed.
-printf 'ERROR: (gcloud.artifacts.docker.images.describe) PERMISSION_DENIED: Could not find valid credentials.\n' > "${image_fixture}"
-if image_not_found "${image_fixture}"; then
-  fail image-not-found-permission-error
-fi
+run_fixture="${temp_dir}/cloud-run-not-found.txt"
+# Observed punctuation differs per surface: jobs end in a period, services and
+# revisions do not. Both renderings must be accepted for every surface.
+printf 'ERROR: (gcloud.run.services.describe) Cannot find service [radar]\n' > "${run_fixture}"
+cloud_run_not_found service radar "${run_fixture}" || fail run-service-not-found-observed
+printf 'ERROR: (gcloud.run.jobs.describe) Cannot find job [device-cleanup].\n' > "${run_fixture}"
+cloud_run_not_found job device-cleanup "${run_fixture}" || fail run-job-not-found-observed
+printf 'ERROR: (gcloud.run.revisions.describe) Cannot find revision [radar-00017-b77]\n' > "${run_fixture}"
+cloud_run_not_found revision radar-00017-b77 "${run_fixture}" || fail run-revision-not-found-observed
 
-# Command: gcloud artifacts docker images describe <image-ref>
-# Source: synthetic unlisted-status fixture; no production capture claimed.
-printf 'ERROR: (gcloud.artifacts.docker.images.describe) DEADLINE_EXCEEDED: Image not found.\n' > "${image_fixture}"
-if image_not_found "${image_fixture}"; then
-  fail image-not-found-unlisted-status
+# A different resource's not-found line must not answer for this one.
+printf 'ERROR: (gcloud.run.services.describe) Cannot find service [geoworker]\n' > "${run_fixture}"
+if cloud_run_not_found service radar "${run_fixture}"; then
+  fail run-not-found-wrong-resource
+fi
+# A status-qualified failure is never a missing resource.
+printf 'ERROR: (gcloud.run.services.describe) PERMISSION_DENIED: Cannot find service [radar]\n' > "${run_fixture}"
+if cloud_run_not_found service radar "${run_fixture}"; then
+  fail run-not-found-status-collision
 fi
 
 git_dir="${temp_dir}/git"
@@ -335,7 +345,10 @@ exit 0
 MOCK
 chmod +x "${temp_dir}/bin/kubectl" "${temp_dir}/bin/gcloud"
 release_functions="${temp_dir}/release-functions.sh"
-sed '/^case "${1:-}" in$/,$d' "${script_dir}/release.sh" > "${release_functions}"
+# The marker must exist, or the extraction below would silently produce a copy
+# of the whole script and every sourced-function test would change meaning.
+grep -Fxq '# === dispatch ===' "${script_dir}/release.sh" || fail dispatch-marker-missing
+sed '/^# === dispatch ===$/,$d' "${script_dir}/release.sh" > "${release_functions}"
 common_env=(PATH="${temp_dir}/bin:${PATH}" RELEASE_SHA="${sha}" BUNDLE_FILE="${bundle}" PROJECT_ID=test PROJECT_NUMBER=123456 REGION=region REGISTRY=registry.example OWNER=repo RUNTIME_SA_EMAIL=runtime@example.invalid ALLOWED_HOST=radar.example.invalid CORS_ALLOWED_ORIGINS=https://app.example.invalid RATE_LIMIT_ENABLED=true RATE_LIMIT_RATE=12 RATE_LIMIT_BURST=40 RATE_LIMIT_EXPIRES_IN=5m GOOGLE_OAUTH_CLIENT_ID=oauth MOCK_JOB_MANIFEST="${temp_dir}/captured-job.yaml" MOCK_MUTATION_MARKER="${temp_dir}/mutation.marker")
 assert_missing_cloud_run_target() {
   local target=$1 snapshot_output preflight_output
@@ -356,6 +369,7 @@ assert_missing_cloud_run_target() {
 }
 assert_missing_cloud_run_target device-cleanup
 assert_missing_cloud_run_target geoworker
+
 describe_error_output="${temp_dir}/describe-error-preflight.txt"
 if env "${common_env[@]}" MOCK_SHA="${sha}" MOCK_RADAR="${digest_a}" MOCK_GEOWORKER="${digest_b}" MOCK_CLEANUP="${digest_c}" \
   MOCK_DESCRIBE_ERROR_TARGET=device-cleanup \
@@ -434,22 +448,22 @@ env "${common_env[@]}" MOCK_SHA="${sha}" MOCK_RADAR="${digest_a}" MOCK_GEOWORKER
   MOCK_REVISION_NOT_FOUND_ONCE=true MOCK_REVISION_MARKER="${revision_marker}" \
   VERIFY_RETRIES=2 VERIFY_RETRY_DELAY=0 SKIP_HEALTH=true \
   bash "${script_dir}/release.sh" verify || fail revision-describe-retry
-sleep_log="${temp_dir}/sleep.log"
+# A fleet that never reaches the release SHA must exhaust its retries and fail
+# rather than report success. The retry schedule itself is a tuning knob, not
+# a contract, so it is deliberately not asserted here.
 cat > "${temp_dir}/bin/sleep" <<'MOCK'
 #!/usr/bin/env bash
-: "${MOCK_SLEEP_LOG:=/dev/null}"
-printf '%s\n' "$1" >> "${MOCK_SLEEP_LOG}"
+exit 0
 MOCK
 chmod +x "${temp_dir}/bin/sleep"
 verify_output="${temp_dir}/verify-nonconverge.txt"
 if env "${common_env[@]}" MOCK_SHA="${parent}" MOCK_RADAR="${digest_a}" MOCK_GEOWORKER="${digest_b}" MOCK_CLEANUP="${digest_c}" \
-  MOCK_SLEEP_LOG="${sleep_log}" SKIP_HEALTH=true \
+  SKIP_HEALTH=true \
   bash "${script_dir}/release.sh" verify >"${verify_output}" 2>&1; then
   fail verify-retry-exhausted
 fi
 grep -F 'released labels, digests, or readiness did not converge' "${verify_output}" >/dev/null \
   || fail verify-retry-message
-printf '5\n10\n20\n30\n30\n30\n30\n30\n30\n' | diff -u - "${sleep_log}" || fail verify-retry-backoff
 
 # Candidate resolution must select the newest complete ancestor when the
 # current control commit only changes non-release paths.
@@ -538,6 +552,7 @@ if run_resolver "${resolver_control}" "${temp_dir}/resolver-pin-non-ancestor-env
 fi
 grep -F 'not an ancestor' "${resolver_pin_non_ancestor_output}" >/dev/null \
   || fail resolver-pin-non-ancestor-message
+
 resolver_pin_incomplete_output="${temp_dir}/resolver-pin-incomplete-output"
 if run_resolver "${resolver_control}" "${temp_dir}/resolver-pin-incomplete-env" "${resolver_candidate}" device-cleanup \
   >"${resolver_pin_incomplete_output}" 2>&1; then
@@ -690,6 +705,8 @@ if (
   fail empty-catalog-guard
 fi
 
+
+
 goose_version=$(make -C "${repo_root}" -s --no-print-directory print-goose-version)
 printf '%s\n' "${goose_version}" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$' || fail goose-version-format
 
@@ -697,14 +714,8 @@ workflow="${repo_root}/.github/workflows/release-cloud-run.yml"
 ci_workflow="${repo_root}/.github/workflows/ci.yml"
 operations_workflow="${repo_root}/.github/workflows/cloud-run-operations.yml"
 
-# Execute the production promotion step with mocked registry tools so a
-# permission error cannot silently authorize a gcrane copy.
-promote_run="${temp_dir}/promote-run.sh"
-ruby -ryaml -e '
-  workflow = YAML.load_file(ARGV.fetch(0))
-  run = workflow.fetch("jobs").fetch("release").fetch("steps").find { |step| step.fetch("name") == "Promote exact digests to prod" }.fetch("run")
-  print run
-' "${workflow}" > "${promote_run}"
+# Execute the production promotion with mocked registry tools so a permission
+# error cannot silently authorize a gcrane copy.
 promote_targets="${temp_dir}/promote-targets.json"
 printf '{"radar":{"kind":"service","overlay":"radar","order":1}}\n' > "${promote_targets}"
 promote_runner="${temp_dir}/promote-runner"
@@ -768,7 +779,8 @@ run_promote() {
       MOCK_PROMOTE_ERROR="${error_mode}" MOCK_PROMOTE_COPY_MARKER="${copy_marker}" \
       MOCK_PROMOTE_DESCRIBE_COUNT="${describe_count}" MOCK_PROMOTE_IMAGE="${promote_image}" \
       MOCK_PROMOTE_EXPECTED_SOURCE="${promote_source}" MOCK_PROMOTE_EXPECTED_DESTINATION="${promote_destination}" \
-      bash "${promote_run}"
+      GCRANE="${promote_runner}/gcrane/gcrane" \
+      bash "${script_dir}/release.sh" promote
   )
 }
 promote_permission_marker="${temp_dir}/promote-permission-copy.marker"
@@ -793,18 +805,12 @@ ruby -ryaml -e '
   operations = YAML.load_file(ARGV.fetch(3))
   raise "ci permissions" unless ci.fetch("permissions").fetch("contents") == "read"
   publish = ci.fetch("jobs").fetch("publish-candidate")
-  changes = ci.fetch("jobs").fetch("candidate-changes").fetch("steps").find { |step| step["id"] == "changes" }
-  quote = 39.chr
-  empty_target_guard = "targets=$(jq -e -c #{quote}keys | select(length > 0)#{quote}"
-  raise "empty target catalog guard" unless changes.fetch("run").include?(empty_target_guard)
-  raise "before inline" if changes.fetch("run").include?("${{ github.event.before }}")
   attest = publish.fetch("steps").find { |step| step["name"] == "Attest staged image digest" }
   verify = publish.fetch("steps").find { |step| step["name"] == "Verify candidate attestation" }
   finalize = publish.fetch("steps").find { |step| step["name"] == "Publish verified candidate SHA tag" }
   publish_names = publish.fetch("steps").map { |step| step.fetch("name") }
   raise "attestation finalization order" unless publish_names.index(attest.fetch("name")) < publish_names.index(verify.fetch("name")) && publish_names.index(verify.fetch("name")) < publish_names.index(finalize.fetch("name"))
   raise "existing attestation fail-closed" unless verify.fetch("run").include?("Existing SHA tag")
-  raise "staging cleanup command" unless finalize.fetch("run").include?("artifacts docker tags delete")
   # The only path from the release_sha input into the script. Break this wiring
   # and a pinned rollback silently resolves the newest candidate and runs
   # migrations instead, because every REQUESTED_SHA branch downstream is
@@ -822,13 +828,19 @@ ruby -ryaml -e '
   names = steps.map { |step| step.fetch("name") }
   raise "release sha inline" if steps.any? { |step| step.fetch("run", "").include?("${{ inputs.release_sha }}") }
   raise "registry auth order" unless names.index("Configure dev Registry auth") < names.index("Resolve and verify candidate digests")
-  raise "mutation guard order" unless names.index("Recheck current main before mutation") < names.index("Promote exact digests to prod")
   preflight = steps.find { |step| step.fetch("name") == "Preflight target state" }
   promote = steps.find { |step| step.fetch("name") == "Promote exact digests to prod" }
   raise "preflight unconditional" unless preflight["if"].nil?
   raise "preflight order" unless names.index(preflight.fetch("name")) < names.index(promote.fetch("name"))
-  migrations = steps.find { |step| step.fetch("name") == "Detect migration phases" }
-  raise "migration pin guard" unless migrations.fetch("run").include?("REQUESTED_SHA")
+  # The not-found matchers decide whether a resource is absent, and that answer
+  # authorizes creates and copies. Proving the wording still holds is only
+  # useful before anything acts on it.
+  contract = steps.find { |step| step.fetch("name") == "Verify gcloud error contract" }
+  raise "error contract unconditional" unless contract["if"].nil?
+  raise "error contract order" unless names.index(contract.fetch("name")) < names.index(preflight.fetch("name"))
+  # A pinned release must be able to refuse itself, so the acknowledgement has
+  # to reach the script rather than only existing as a dispatch input.
+  raise "schema drift ack env" unless release_env.fetch("ACKNOWLEDGE_SCHEMA_DRIFT") == "${{ inputs.acknowledge_schema_drift }}"
   task = job.fetch("spec").fetch("template").fetch("spec").fetch("template").fetch("spec")
   container = task.fetch("containers").first
   raise "job secret" unless container.fetch("env").any? { |env| env.fetch("name") == "POSTGRES_MASTER_DSN" }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,24 +69,7 @@ jobs:
         id: changes
         env:
           BEFORE_SHA: ${{ github.event.before }}
-        run: |
-          set -euo pipefail
-          path_args=()
-          while IFS= read -r path; do
-            path_args+=("${path}")
-          done < <(bash .github/scripts/release/release.sh impact-paths)
-          test "${#path_args[@]}" -gt 0
-          before="${BEFORE_SHA}"
-          candidate=true
-          if printf '%s' "${before}" | grep -Eq '^[0]{40}$' \
-            || ! git cat-file -e "${before}^{commit}" 2>/dev/null; then
-            echo "Force-push or missing before SHA: publishing a complete candidate."
-          elif git diff --quiet "${before}..${GITHUB_SHA}" -- "${path_args[@]}"; then
-            candidate=false
-          fi
-          echo "candidate=${candidate}" >> "${GITHUB_OUTPUT}"
-          targets=$(jq -e -c 'keys | select(length > 0)' "${TARGETS_FILE}")
-          echo "targets=${targets}" >> "${GITHUB_OUTPUT}"
+        run: bash .github/scripts/release/release.sh candidate-changes
 
   publish-candidate:
     name: Publish ${{ matrix.target }} candidate image
@@ -128,7 +111,6 @@ jobs:
               exit 1
             fi
           done
-          jq -e --arg target "${TARGET}" '.[$target] != null' "${TARGETS_FILE}" >/dev/null
 
       - name: Google Auth
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
@@ -148,71 +130,7 @@ jobs:
 
       - name: Build and stage candidate image
         id: stage
-        run: |
-          set -euo pipefail
-          # shellcheck source=.github/scripts/release/not_found.sh
-          source .github/scripts/release/not_found.sh
-          owner=$(printf '%s' "${OWNER}" | tr '[:upper:]' '[:lower:]')
-          echo "owner=${owner}" >> "${GITHUB_OUTPUT}"
-          built=$(git show -s --format=%cI "${RELEASE_SHA}")
-          final_ref="${REGISTRY}/${owner}/${TARGET}:${RELEASE_SHA}"
-          describe_error=$(mktemp "${RUNNER_TEMP}/candidate-describe.XXXXXX")
-          if existing=$(gcloud artifacts docker images describe "${final_ref}" \
-            --project="${PROJECT_ID}" \
-            --format='value(image_summary.fully_qualified_digest)' 2>"${describe_error}"); then
-            rm -f "${describe_error}"
-            existing=$(printf '%s' "${existing}" | tr -d '\r\n')
-            expected_base="${REGISTRY}/${owner}/${TARGET}"
-            if [ "${existing%@*}" != "${expected_base}" ] || ! printf '%s' "${existing}" | grep -Eq '@sha256:[0-9a-f]{64}$'; then
-              echo "::error::Existing candidate image for ${TARGET} did not resolve to an exact digest."
-              exit 1
-            fi
-            {
-              echo "digest=${existing##*@}"
-              echo "staging_ref="
-              echo "needs_finalize=false"
-            } >> "${GITHUB_OUTPUT}"
-            exit 0
-          fi
-          if ! image_not_found "${describe_error}"; then
-            cat "${describe_error}" >&2
-            rm -f "${describe_error}"
-            echo "::error::Unable to inspect candidate image for ${TARGET}."
-            exit 1
-          fi
-          rm -f "${describe_error}"
-          nonce=$(openssl rand -hex 16)
-          staging_ref="${REGISTRY}/${owner}/${TARGET}:candidate-stage-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${nonce}-${TARGET}"
-          docker buildx build \
-            --file ./Dockerfile \
-            --target "${TARGET}" \
-            --platform linux/amd64 \
-            --pull \
-            --provenance=false \
-            --sbom=false \
-            --build-arg "VERSION=${RELEASE_SHA}" \
-            --build-arg "BUILT=${built}" \
-            --build-arg "GIT_COMMIT=${RELEASE_SHA}" \
-            --build-arg "IMAGE_NAME=${owner}" \
-            --cache-from "type=gha,scope=${TARGET}" \
-            --cache-to "type=gha,mode=max,scope=${TARGET}" \
-            --tag "${staging_ref}" \
-            --push \
-            .
-          staged=$(gcloud artifacts docker images describe "${staging_ref}" \
-            --project="${PROJECT_ID}" \
-            --format='value(image_summary.fully_qualified_digest)')
-          staged=$(printf '%s' "${staged}" | tr -d '\r\n')
-          expected_base="${REGISTRY}/${owner}/${TARGET}"
-          if [ "${staged%@*}" != "${expected_base}" ] || ! printf '%s' "${staged}" | grep -Eq '@sha256:[0-9a-f]{64}$'; then
-            echo "::error::Staged candidate image for ${TARGET} did not resolve to an exact digest."
-            exit 1
-          fi
-          {
-            echo "digest=${staged##*@}"
-            echo "staging_ref=${staging_ref}"
-            echo "needs_finalize=true"
-          } >> "${GITHUB_OUTPUT}"
+        run: bash .github/scripts/release/release.sh stage-candidate
 
       - name: Attest staged image digest
         if: steps.stage.outputs.needs_finalize == 'true'
@@ -225,65 +143,22 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           NEEDS_FINALIZE: ${{ steps.stage.outputs.needs_finalize }}
-          STAGED_DIGEST: ${{ steps.stage.outputs.digest }}
+          IMAGE: ${{ env.REGISTRY }}/${{ steps.stage.outputs.owner }}/${{ env.TARGET }}@${{ steps.stage.outputs.digest }}
         run: |
           set -euo pipefail
-          owner=$(printf '%s' "${OWNER}" | tr '[:upper:]' '[:lower:]')
-          image="${REGISTRY}/${owner}/${TARGET}@${STAGED_DIGEST}"
-          attempt=1
-          while ! gh attestation verify "oci://${image}" \
-            --repo "${GITHUB_REPOSITORY}" \
-            --signer-workflow "${GITHUB_REPOSITORY}/.github/workflows/ci.yml" \
-            --source-ref refs/heads/main \
-            --source-digest "${RELEASE_SHA}" \
-            --deny-self-hosted-runners \
-            --predicate-type https://slsa.dev/provenance/v1; do
-            if [ "${attempt}" -ge 4 ]; then
-              if [ "${NEEDS_FINALIZE}" = false ]; then
-                echo "::error::Existing SHA tag for ${TARGET} has no valid attestation; stop and follow the approved manual recovery procedure before retrying."
-              else
-                echo "::error::Candidate attestation did not become visible for ${TARGET}."
-              fi
-              exit 1
-            fi
-            sleep 5
-            attempt=$((attempt + 1))
-          done
+          if bash .github/scripts/release/release.sh verify-attestation; then
+            exit 0
+          fi
+          if [ "${NEEDS_FINALIZE}" = false ]; then
+            echo "::error::Existing SHA tag for ${TARGET} has no valid attestation; stop and follow the approved manual recovery procedure before retrying."
+          else
+            echo "::error::Candidate attestation did not become visible for ${TARGET}."
+          fi
+          exit 1
 
       - name: Publish verified candidate SHA tag
         env:
           NEEDS_FINALIZE: ${{ steps.stage.outputs.needs_finalize }}
           STAGING_REF: ${{ steps.stage.outputs.staging_ref }}
           STAGED_DIGEST: ${{ steps.stage.outputs.digest }}
-        run: |
-          set -euo pipefail
-          owner=$(printf '%s' "${OWNER}" | tr '[:upper:]' '[:lower:]')
-          final_ref="${REGISTRY}/${owner}/${TARGET}:${RELEASE_SHA}"
-          if [ "${NEEDS_FINALIZE}" = true ]; then
-            source_digest_ref="${STAGING_REF%:*}@${STAGED_DIGEST}"
-            gcloud artifacts docker tags add "${source_digest_ref}" "${final_ref}" \
-              --project="${PROJECT_ID}"
-          fi
-          final_digest=$(gcloud artifacts docker images describe "${final_ref}" \
-            --project="${PROJECT_ID}" \
-            --format='value(image_summary.fully_qualified_digest)')
-          final_digest=$(printf '%s' "${final_digest}" | tr -d '\r\n')
-          expected="${REGISTRY}/${owner}/${TARGET}@${STAGED_DIGEST}"
-          [ "${final_digest}" = "${expected}" ] || {
-            echo "::error::Final candidate tag for ${TARGET} does not equal the attested digest."
-            exit 1
-          }
-          if [ -n "${STAGING_REF}" ]; then
-            gcloud artifacts docker tags delete "${STAGING_REF}" \
-              --project="${PROJECT_ID}" --quiet \
-              || echo "::warning::Could not delete staging tag ${STAGING_REF}; immutable-tag repositories may retain it."
-          fi
-          {
-            echo "## Candidate image"
-            echo
-            echo "Release SHA: \`${RELEASE_SHA}\`"
-            echo
-            echo "| Target | Digest |"
-            echo "| --- | --- |"
-            echo "| ${TARGET} | \`${final_digest##*@}\` |"
-          } >> "${GITHUB_STEP_SUMMARY}"
+        run: bash .github/scripts/release/release.sh finalize-candidate

--- a/.github/workflows/release-cloud-run.yml
+++ b/.github/workflows/release-cloud-run.yml
@@ -9,10 +9,15 @@ on:
         type: choice
         options: [dev, prod]
       release_sha:
-        description: "Pin a specific candidate commit SHA (40 hex). Empty = newest candidate."
+        description: "Pin a candidate commit SHA, abbreviated (7+) or full. Empty = newest candidate."
         required: false
         default: ""
         type: string
+      acknowledge_schema_drift:
+        description: "Pinned releases only: proceed even though the pin crosses a migration change. Handle the schema first."
+        required: false
+        default: false
+        type: boolean
 
 env:
   GCRANE_VERSION: v0.21.9
@@ -34,6 +39,7 @@ jobs:
       CONTROL_SHA: ${{ github.sha }}
       TARGET_ENVIRONMENT: ${{ inputs.environment }}
       REQUESTED_SHA: ${{ inputs.release_sha }}
+      ACKNOWLEDGE_SCHEMA_DRIFT: ${{ inputs.acknowledge_schema_drift }}
       PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
       PROJECT_NUMBER: ${{ vars.GCP_PROJECT_NUMBER }}
       REGION: ${{ vars.GCP_REGION }}
@@ -103,6 +109,11 @@ jobs:
         with:
           project_id: ${{ env.PROJECT_ID }}
 
+      # Missing-resource detection depends on exact gcloud error strings. Prove
+      # they still hold before anything in this run can act on them.
+      - name: Verify gcloud error contract
+        run: bash .github/scripts/release/release.sh check-error-contract
+
       - name: Configure dev Registry auth
         run: gcloud auth configure-docker "${DEV_REGISTRY%%/*}" --quiet
 
@@ -124,35 +135,7 @@ jobs:
         env:
           RELEASE_SHA: ${{ steps.candidate.outputs.release_sha }}
           BASELINE_SHA: ${{ steps.preflight.outputs.baseline_sha }}
-        run: |
-          set -euo pipefail
-          if [ -n "${REQUESTED_SHA:-}" ]; then
-            printf 'pre=false\nshared=false\npost=false\nany=false\n' >> "${GITHUB_OUTPUT}"
-            echo "::notice::Pinned release: migrations skipped. Handle schema separately."
-            exit 0
-          fi
-          changed() {
-            if git diff --quiet "${BASELINE_SHA}..${RELEASE_SHA}" -- "$1"; then
-              return 1
-            else
-              status=$?
-              [ "${status}" -eq 1 ] || exit "${status}"
-              return 0
-            fi
-          }
-          if [ -z "${BASELINE_SHA}" ]; then
-            pre=true; shared=true; post=true
-          elif [ "${BASELINE_SHA}" = "${RELEASE_SHA}" ]; then
-            pre=false; shared=false; post=false
-          else
-            pre=false; shared=false; post=false
-            changed database/migration/supabase/pre && pre=true
-            changed database/migration/postgres && shared=true
-            changed database/migration/supabase/post && post=true
-          fi
-          any=false
-          { [ "${pre}" = false ] && [ "${shared}" = false ] && [ "${post}" = false ]; } || any=true
-          printf 'pre=%s\nshared=%s\npost=%s\nany=%s\n' "${pre}" "${shared}" "${post}" "${any}" >> "${GITHUB_OUTPUT}"
+        run: bash .github/scripts/release/release.sh migration-phases
 
       - name: Set up Go for migrations
         if: steps.migrations.outputs.any == 'true'
@@ -197,16 +180,11 @@ jobs:
           SKIP_HEALTH: "true"
         run: bash .github/scripts/release/release.sh verify
 
-      - name: Recheck current main before mutation
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Configure prod Registry auth
+        if: inputs.environment == 'prod'
         run: |
           set -euo pipefail
-          remote_sha=$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/main" --jq .object.sha)
-          test "${remote_sha}" = "${CONTROL_SHA}" || {
-            echo "::error::Main advanced before mutation; start a new release run."
-            exit 1
-          }
+          gcloud auth configure-docker "${DEV_REGISTRY%%/*},${REGISTRY%%/*}" --quiet
 
       - name: Promote exact digests to prod
         if: inputs.environment == 'prod'
@@ -214,47 +192,8 @@ jobs:
         env:
           SOURCE_BUNDLE: ${{ steps.candidate.outputs.path }}
           RELEASE_SHA: ${{ steps.candidate.outputs.release_sha }}
-        run: |
-          set -euo pipefail
-          # shellcheck source=.github/scripts/release/not_found.sh
-          source .github/scripts/release/not_found.sh
-          owner=$(printf '%s' "${OWNER}" | tr '[:upper:]' '[:lower:]')
-          dev_host=$(printf '%s' "${DEV_REGISTRY}" | cut -d/ -f1)
-          prod_host=$(printf '%s' "${REGISTRY}" | cut -d/ -f1)
-          gcloud auth configure-docker "${dev_host},${prod_host}" --quiet
-          promoted='{}'
-          while IFS= read -r target; do
-            # Preflight has already validated the complete target set and pinned digests.
-            source=$(jq -r --arg target "${target}" '.images[$target]' "${SOURCE_BUNDLE}")
-            destination="${REGISTRY}/${owner}/${target}:${RELEASE_SHA}"
-            describe_error=$(mktemp "${RUNNER_TEMP}/prod-describe.XXXXXX")
-            if existing=$(gcloud artifacts docker images describe "${destination}" \
-              --project="${PROJECT_ID}" --format='value(image_summary.fully_qualified_digest)' 2>"${describe_error}"); then
-              rm -f "${describe_error}"
-              [ "${existing##*@}" = "${source##*@}" ] || {
-                echo "::error::Immutable prod tag already points to a different digest: ${target}"
-                exit 1
-              }
-            else
-              image_not_found "${describe_error}" || {
-                cat "${describe_error}" >&2
-                rm -f "${describe_error}"
-                echo "::error::Unable to inspect prod image: ${target}"
-                exit 1
-              }
-              rm -f "${describe_error}"
-              "${RUNNER_TEMP}/gcrane/gcrane" copy "${source}" "${destination}"
-            fi
-            image=$(gcloud artifacts docker images describe "${destination}" \
-              --project="${PROJECT_ID}" --format='value(image_summary.fully_qualified_digest)')
-            expected="${REGISTRY}/${owner}/${target}@${source##*@}"
-            [ "${image}" = "${expected}" ] || { echo "::error::Prod digest verification failed: ${target}"; exit 1; }
-            promoted=$(jq -c --arg target "${target}" --arg image "${image}" '. + {($target):$image}' <<<"${promoted}")
-          done < <(jq -r 'keys[]' "${TARGETS_FILE}")
-          bundle="${RUNNER_TEMP}/promoted-bundle.json"
-          jq -cn --arg sha "${RELEASE_SHA}" --argjson images "${promoted}" \
-            '{release_sha:$sha,images:$images}' > "${bundle}"
-          echo "path=${bundle}" >> "${GITHUB_OUTPUT}"
+          GCRANE: ${{ runner.temp }}/gcrane/gcrane
+        run: bash .github/scripts/release/release.sh promote
 
       - name: Run selected migration phases
         if: steps.migrations.outputs.any == 'true'

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,81 @@
+# NomNom-Radar
+
+A backend for mobile-vendor and market discovery: consumers find vendors and
+vendor clusters, and vendors notify subscribed consumers when they are nearby.
+
+This glossary exists because several words in this repository mean more than
+one thing depending on where you are standing, and each collision has already
+produced a real defect.
+
+## Release and delivery
+
+**Target**:
+One deployable unit in the release catalog — `radar`, `geoworker`, or
+`device-cleanup`. A target is a build stage, an image repository, and a Cloud
+Run resource under one name.
+_Avoid_: service (a target may be a Cloud Run Job), component, unit
+
+**Target environment**:
+`dev` or `prod`. Always name it in full, including in variables. A bare
+`target` never means an environment.
+_Avoid_: env, stage, deployment target
+
+**Candidate**:
+A `main` commit for which every target has a complete, attested image in the
+dev registry. Candidacy is a property of a commit, not of a build.
+_Avoid_: build, artifact, release candidate
+
+**Needs candidate**:
+The decision that a push changed a release-impacting path and must therefore
+publish new images. This is a boolean about work to do, not the noun above.
+_Avoid_: candidate (as a boolean)
+
+**Release SHA**:
+The candidate commit a release is deploying. Also the value of the
+`release-sha` Cloud Run label on every target.
+_Avoid_: version, deployed SHA
+
+**Control SHA**:
+The `main` commit that supplied the running workflow definition. Automation
+always executes from this commit; it is not necessarily the release SHA.
+_Avoid_: workflow SHA, current SHA
+
+**Baseline**:
+The release SHA a target environment's fleet is running before this release.
+Migration selection is the diff between the baseline and the release SHA.
+_Avoid_: previous release, last deploy, current version
+
+**Pinned release**:
+A release that names its release SHA directly instead of resolving the newest
+compatible ancestor. Used for rollback. It runs no migrations.
+_Avoid_: rollback (a pin may also move forward), manual release
+
+**Impact path**:
+A repository path whose change requires new candidate images. The list is
+`impact_path_args()` in `release.sh` and nothing else.
+_Avoid_: watched path, trigger path
+
+**Promotion**:
+Copying an exact dev digest into the prod registry without rebuilding.
+Promotion never produces a new image.
+_Avoid_: prod build, republish, deploy to prod
+
+**Bundle**:
+The run-local JSON mapping a release SHA to one exact digest per target. It
+exists only for the duration of a workflow run.
+_Avoid_: manifest (that word is the rendered Cloud Run YAML), lockfile
+
+## Review
+
+Two unrelated controls are both called review. Never use the bare word.
+
+**Merge review**:
+The `main` ruleset's pull-request approval requirement, which decides what
+reaches `main`. Repository admins bypass it.
+_Avoid_: review, approval, PR gate
+
+**Deployment review**:
+The `prod` GitHub Environment's required-reviewers rule, which decides whether
+a dispatched prod run may proceed. It is unrelated to pull requests, and with a
+single maintainer it is a confirmation pause rather than separation of duties.
+_Avoid_: review, approval, prod gate

--- a/docs/adr/0001-attested-candidate-images.md
+++ b/docs/adr/0001-attested-candidate-images.md
@@ -1,0 +1,37 @@
+# Candidate images get their immutable SHA tag only after attestation
+
+CI builds each candidate image to a run-scoped staging tag, resolves its exact
+digest, attests that digest, verifies the attestation, and only then adds the
+immutable `:<commit-sha>` tag and deletes the staging tag. The obvious
+alternative — build and push straight to the SHA tag, then attest — is roughly
+twenty lines shorter, and it is what a reader will be tempted to collapse this
+back into.
+
+## Why
+
+Two reasons, and the second is the one that is easy to miss.
+
+**A compromised registry credential must not be able to supply a release
+input.** `GCP_CANDIDATE_SA_KEY` is a long-lived JSON service account key with
+write access to the dev registry, and this repository is public. Without
+attestation, anyone holding that key could push an image under a legitimate
+commit SHA tag and the resolver would deploy it to prod. Immutable tags alone
+do not close this: they prevent overwriting an existing tag, but not creating
+one for a commit CI never built — for example a docs-only commit, which is
+exactly what a pinned release is able to select.
+
+**An immutable tag cannot be removed, so publishing it before attestation
+turns any interruption into a permanently unreleasable commit.** If CI pushes
+the SHA tag and then fails before attesting, that digest can never be attested
+afterwards — the release path refuses to re-attest an existing digest, by
+design. The commit is then bricked, and recovery means quarantining the SHA and
+publishing a new release-impacting commit. The staging tag exists so that an
+interrupted run leaves behind a throwaway tag instead of a permanent one. This
+reason is operational rather than adversarial, and it survives unchanged even
+if the credential risk is later removed.
+
+## Consequences
+
+Moving the candidate publisher to Workload Identity Federation would weaken the
+first reason considerably but leaves the second one untouched. Do not treat WIF
+adoption as grounds for collapsing the staging step.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -90,15 +90,21 @@ resources and ancestral to the selected candidate. A pinned release requires
 the selected SHA to be an ancestor of current `main`; it permits a forward or
 rollback move only when the current baseline and selected SHA are comparable
 ancestors of current `main`. An unpinned release to a new environment with no
-resources bootstraps by checking every migration phase. Pinned releases skip
-migrations and require separate schema handling. A partial retry is accepted only
-when labels contain that consistent baseline and the current target, or when
-missing/unlabeled resources are paired only with the target.
+resources bootstraps by checking every migration phase. A partial retry is
+accepted only when labels contain that consistent baseline and the current
+target, or when missing/unlabeled resources are paired only with the target.
+
+Pinned releases do not run migrations. Because the schema is forward-only, a
+pin that sits on the other side of a migration change from the running
+baseline would put old code in front of a schema it has never seen. The
+release refuses that case: `migration-phases` compares
+`database/migration/**` between the pin and the baseline and fails closed
+unless the dispatch also sets `acknowledge_schema_drift`. Handle the schema
+first, then re-dispatch with the acknowledgement. A pin that crosses no
+migration change needs no acknowledgement.
 
 Divergent history, a third SHA, invalid labels, and label/image drift fail
-closed. A pinned rollback skips all migration phases and requires schema
-handling separately; database changes remain forward-only. A same-target retry
-relies on goose to no-op versions already applied.
+closed. A same-target retry relies on goose to no-op versions already applied.
 
 The dedicated GCP Secret Manager secret `postgres-migration-dsn` is required.
 There is no fallback to `postgres-master-dsn`. Supabase migrations must use a
@@ -122,12 +128,39 @@ and other non-impacting commits do not rebuild images.
 The checked-in target catalog at `.github/scripts/release/targets.json` is the
 single source for the three release targets and their deployment order. The
 impact path list in `impact_path_args()` in `.github/scripts/release/release.sh`
-is the single source for paths that require a new candidate image. The
-`release.sh impact-paths` command is the consumption interface used by CI
-change detection. The resolver calls `impact_path_args()` directly from
-`release.sh`. Adding a path only requires changing that function; its output
-determines whether an older candidate remains compatible with current release
-automation.
+is the single source for paths that require a new candidate image. Adding a
+path only requires changing that function; its output determines whether an
+older candidate remains compatible with current release automation.
+
+### Where release logic lives
+
+Every step the workflows perform lives in `.github/scripts/release/release.sh`
+as a subcommand, so that `release_test.sh` can reach it. A workflow step is a
+call to one of these plus the GitHub Actions that cannot be expressed in bash
+(authentication, buildx, `actions/attest`). Do not inline release logic in
+YAML: anything written there is untested by construction.
+
+| Subcommand | Used by |
+|---|---|
+| `impact-paths` | documentation and manual inspection |
+| `check-error-contract` | release, before anything reads resource state |
+| `candidate-changes` | CI, to decide whether to publish |
+| `stage-candidate` / `verify-attestation` / `finalize-candidate` | CI candidate publication |
+| `resolve-candidate` | release, to select and verify the candidate |
+| `preflight` | release, to validate fleet state and pick the baseline |
+| `migration-phases` | release, to select goose phases |
+| `promote` | prod release, to copy digests into the prod registry |
+| `deploy` / `verify` | release |
+
+Functions above the `# === dispatch ===` marker are sourced directly by
+`release_test.sh`. Keep that marker line exactly as written.
+
+Missing-resource detection is concentrated in `not_found.sh`. Every matcher
+there accepts only a real `NOT_FOUND` status token or one complete, exactly
+observed error line; whole-line matching is what makes a status denylist
+unnecessary. Those literals are re-probed against the live API by
+`check-error-contract` on every release, because a fixture can only prove that
+the parsing still reads the old string, never that gcloud still emits it.
 
 The resolver checks at most the newest 50 first-parent commits. If no complete
 compatible candidate is found in that window, publish a new release-impacting
@@ -159,13 +192,19 @@ older candidate in that case.
 ### Release Cloud Run
 
 `Release Cloud Run` has a required `environment` input, either `dev` or `prod`,
-and an optional `release_sha` input containing a full 40-character commit SHA.
-An empty `release_sha` makes the workflow execute only current protected
-automation (`CONTROL_SHA`) and walk first-parent history to select the newest
-ancestor with all three complete, attested candidate images (`RELEASE_SHA`).
-When `release_sha` is supplied, the resolver selects that SHA directly, still
+and an optional `release_sha` input containing a commit SHA, abbreviated to at
+least 7 hexadecimal characters or given in full. An empty `release_sha` makes
+the workflow execute only current protected automation (`CONTROL_SHA`) and walk
+first-parent history to select the newest ancestor with all three complete,
+attested candidate images (`RELEASE_SHA`). When `release_sha` is supplied, the
+resolver expands it to the full SHA, selects that commit directly, still
 requires complete immutable images and valid attestations, and skips the
 impact-path freshness check.
+
+An abbreviation is expanded with `git rev-parse --verify`, which rejects both
+unknown and ambiguous prefixes, so widening the accepted input does not widen
+what can be deployed. Image tags are always the full 40 characters; everything
+downstream of the resolver, including the bundle, carries the expanded form.
 
 This separation allows a docs-only commit after a verified dev release to
 promote that same candidate without rebuilding it. The resolver rejects any
@@ -173,21 +212,42 @@ candidate whose range to `CONTROL_SHA` changes a release-impacting path. If no
 compatible complete candidate exists, the release fails closed and a new
 release-impacting commit must produce one.
 
-The checked-in workflow verifies the control SHA against remote `main` and
-rejects all reruns. Dispatch a new release run for every retry. Those checks do
-not protect against someone dispatching a historical workflow definition that
-predates them.
-Therefore the prod GitHub Environment requires an external reviewer gate for
-both release and operations jobs. Configure it to prevent self-review: the
-actor who triggered the run must not approve it. Before approval, the reviewer
-must confirm the run's `github.sha` is the current remote `main` HEAD. Dev may
-remain main-only without a required reviewer.
+The checked-in workflow verifies the control SHA against remote `main` once,
+before any read or mutation, and rejects all reruns. Dispatch a new release run
+for every retry. Those checks do not protect against someone dispatching a
+historical workflow definition that predates them.
+
+### What the review gates actually enforce
+
+Two different controls are both called "review". Keep them apart.
+
+**Merge review** decides what reaches `main`. The `main` ruleset requires a
+pull request with one approving review, and bypass is granted to the repository
+admin role only. In practice that means a non-admin collaborator's pull request
+needs an approval, and the admin's own merges do not. Dependabot pull requests
+are authored by the bot, so an admin merging them is also merging without a
+second pair of eyes: the protection against a poisoned action bump is reading
+the diff, not the ruleset.
+
+**Deployment review** decides whether a dispatched prod run may proceed. It is
+the `prod` GitHub Environment's `required_reviewers` rule, and it is unrelated
+to pull requests. This repository has one maintainer, `prevent_self_review` is
+`false`, and the maintainer is the only listed reviewer. The gate is therefore
+a deliberate pause before prod is touched, not separation of duties, and it
+does not defend against the dispatcher. Use the pause to confirm that the run's
+`github.sha` is the current remote `main` HEAD. Dev has no required reviewer.
+
+Turning this into real separation of duties requires setting
+`prevent_self_review` to `true` and adding a second reviewer with access to the
+`prod` environment. Until that happens, do not write automation whose safety
+argument depends on a second person existing.
 
 A release processes the complete bundle in this order:
 
+0. Re-probe the gcloud not-found error contract against the live API.
 1. For prod, verify dev and copy exact digests into the prod registry.
-2. Run required migration phases; pinned releases skip migrations and require
-   separate schema handling.
+2. Run required migration phases; pinned releases skip migrations and must
+   clear the schema-drift check described above.
 3. Deploy `geoworker`, `device-cleanup`, then `radar`.
 4. Verify `release-sha`, exact digest, readiness, and Radar `/health`.
 


### PR DESCRIPTION
Started from a suspicion that the CI/CD was over-engineered. Measuring it first
changed the target: before PR #125 this repo had **six** workflows and 1101
lines of YAML, against three workflows and 844 lines now. The workflow count
was never the problem. The 852-line test file, grown from zero in five days,
was 38% of the CI/CD surface — and it could not see the failure most likely to
actually happen.

## What changed

**Release logic left YAML.** Candidate staging, the attestation retry, prod
digest promotion, change detection, and migration phase selection were inline
in workflow steps, which made them the only release logic with no test
coverage — `release_test.sh` can only reach the script. `ci.yml` drops from 289
to 164 lines and those ~140 lines are now tested.

**Three defects surfaced while moving them:**

- Missing-resource detection matched gcloud error text loosely enough that a
  status-qualified failure could read as "not there". That answer authorizes
  creates and copies. Matchers now accept a `NOT_FOUND` status token or one
  complete, exactly observed line.
- `describe_resource` guessed at three JSON paths for a job image and two for
  a revision image. Checked against live dev resources: exactly one of each is
  populated, the rest return nothing. They now fail closed rather than yield an
  empty string that later looks like digest drift.
- A pinned release skipped migrations behind a grey `::notice::`. The schema is
  forward-only, so a pin crossing a migration change put old code in front of a
  schema it had never seen. It now fails closed unless the dispatch sets
  `acknowledge_schema_drift`.

**Fixtures cannot police an external contract.** The old suite mocked gcloud's
stderr, so a wording change on Google's side would break releases while the
tests stayed green. Four of its five error fixtures were labelled synthetic.
The literals are now all captured from live gcloud, and
`release.sh check-error-contract` re-probes them against the real API at the
start of every release — before anything acts on the answer. No new workflow,
no new credential: the release is already authenticated there.

**Pinned rollback accepts abbreviated SHAs again.** `git rev-parse` expands
them and rejects unknown and ambiguous prefixes. Requiring 40 characters made
the rollback path hardest to use at exactly the wrong moment. (This restores
behaviour that PR #125 removed.)

**The docs described a control that does not exist.** `operations.md` required
the prod environment to prevent self-review; `prevent_self_review` is `false`
and the only reviewer is the sole maintainer. Automation had already been
written against that missing control — the second remote-main check guarded an
approval window with only one actor in it, and is removed. The document now
separates merge review from deployment review and states what each enforces.

## Line count, honestly

Non-test code went **up** by ~130 lines. Deduplication saved lines; the error
contract, the schema-drift guard, and unified change detection cost more. What
improved is coverage, not size: workflow YAML fell from 844 to 658 lines and
the untested portion of it went to zero.

## Verification

- `release_test.sh` passes at **each of the four commits** independently.
- Mutation-tested: removing the schema-drift guard, loosening the not-found
  matcher, and reverting the job-image guard each fail a specific test.
- `check-error-contract` run against live gcloud (dev project, read-only
  describes of non-existent resources): passes, and fails closed with an
  actionable message when a matcher is deliberately broken.
- **Not verified:** `stage-candidate`, `finalize-candidate`, and `promote` have
  mock coverage only — they are the most-moved code. Suggested order: merge and
  let CI publish a candidate, then dispatch a dev release before prod.
- `shellcheck` not run (not installed locally).

## Deliberately not in scope

`cloud-run-operations.yml` is untouched: it is fully decoupled from the release
path and its value goes up under Workload Identity Federation. Migrating the
three static SA keys to WIF is the agreed follow-up — see ADR 0001 for why that
does **not** make the staging-tag step removable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release workflows now support abbreviated commit SHAs.
  * Added staged candidate publication, attestation verification, finalization, and promotion steps.
  * Added schema-drift acknowledgement for pinned releases.
  * Added migration-phase detection and partial-retry support.

* **Reliability & Security**
  * Releases now fail closed when required cloud resources, images, or validation contracts are missing or unexpected.
  * Improved handling of retries, image integrity, and deployment verification.

* **Documentation**
  * Added release terminology, operational guidance, and architecture documentation for attested candidate images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->