### PR TITLE
docs: describe the registry's actual tag mutability, and drop a cleanup that cannot run

### DIFF
--- a/.github/scripts/release/release.sh
+++ b/.github/scripts/release/release.sh
@@ -326,9 +326,16 @@ finalize_candidate() {
   [ "${final_digest##*@}" = "${STAGED_DIGEST}" ] \
     || integrity_die "final candidate tag for ${TARGET} does not equal the attested digest"
   if [ -n "${STAGING_REF:-}" ]; then
+    # Expected to fail today: roles/artifactregistry.writer grants
+    # artifactregistry.tags.create and .update but not .delete, so the candidate
+    # identity cannot remove its own staging tag. The tag is an alias for a
+    # digest that already carries its SHA tag, so it costs no extra storage and
+    # is not a release input; it disappears with its image version when the
+    # repository cleanup policy removes it. Left as a warning rather than a
+    # failure because the candidate is already published and verified by here.
     gcloud artifacts docker tags delete "${STAGING_REF}" \
       --project="${PROJECT_ID}" --quiet \
-      || printf '::warning::Could not delete staging tag %s; immutable-tag repositories may retain it.\n' "${STAGING_REF}"
+      || printf '::warning::Could not delete staging tag %s; the candidate identity has no artifactregistry.tags.delete. The tag expires with its image version.\n' "${STAGING_REF}"
   fi
   {
     echo '## Candidate image'

--- a/docs/adr/0001-attested-candidate-images.md
+++ b/docs/adr/0001-attested-candidate-images.md
@@ -1,8 +1,8 @@
-# Candidate images get their immutable SHA tag only after attestation
+# Candidate images get their SHA tag only after attestation
 
 CI builds each candidate image to a run-scoped staging tag, resolves its exact
 digest, attests that digest, verifies the attestation, and only then adds the
-immutable `:<commit-sha>` tag and deletes the staging tag. The obvious
+`:<commit-sha>` tag and deletes the staging tag. The obvious
 alternative — build and push straight to the SHA tag, then attest — is roughly
 twenty lines shorter, and it is what a reader will be tempted to collapse this
 back into.
@@ -15,22 +15,28 @@ Two reasons, and the second is the one that is easy to miss.
 input.** `GCP_CANDIDATE_SA_KEY` is a long-lived JSON service account key with
 write access to the dev registry, and this repository is public. Without
 attestation, anyone holding that key could push an image under a legitimate
-commit SHA tag and the resolver would deploy it to prod. Immutable tags alone
-do not close this: they prevent overwriting an existing tag, but not creating
-one for a commit CI never built — for example a docs-only commit, which is
-exactly what a pinned release is able to select.
+commit SHA tag and the resolver would deploy it to prod. Neither registry
+enables immutable tags — see "Tag mutability" in `docs/operations.md` for why
+that is deliberate — so attestation is the only control that rejects a tag
+pointing at a digest CI never built. It is load-bearing on its own.
 
-**An immutable tag cannot be removed, so publishing it before attestation
-turns any interruption into a permanently unreleasable commit.** If CI pushes
-the SHA tag and then fails before attesting, that digest can never be attested
-afterwards — the release path refuses to re-attest an existing digest, by
-design. The commit is then bricked, and recovery means quarantining the SHA and
-publishing a new release-impacting commit. The staging tag exists so that an
-interrupted run leaves behind a throwaway tag instead of a permanent one. This
-reason is operational rather than adversarial, and it survives unchanged even
-if the credential risk is later removed.
+**A SHA tag published before attestation cannot be repaired by CI.** If CI
+pushes the SHA tag and then fails before attesting, that digest can never be
+attested afterwards: the release path refuses to re-attest an existing digest,
+by design. Because tags here are mutable, the commit is not permanently lost —
+but removing the tag needs `artifactregistry.tags.delete`, which the candidate
+identity does not hold. Recovery therefore stops being automatic and becomes a
+registry-admin break-glass action, or a quarantined SHA and a fresh
+release-impacting commit. The staging tag exists so that an interrupted run
+leaves a throwaway tag that nothing consults, instead of a published one that
+requires a privileged human to clean up.
 
 ## Consequences
+
+Enabling `--immutable-tags` later would strengthen the first reason and turn the
+second into a genuinely unrecoverable commit rather than an awkward one. It
+would also block deletion of tagged images and break the cleanup policies both
+repositories depend on, so it is not a free hardening step.
 
 Moving the candidate publisher to Workload Identity Federation would weaken the
 first reason considerably but leaves the second one untouched. Do not treat WIF

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -121,9 +121,22 @@ Never run `DROP EXTENSION postgis CASCADE` on a migrated database.
 
 Release-impacting merges to `main` publish `radar`, `geoworker`, and
 `device-cleanup` to the dev Artifact Registry. Images use the full commit SHA
-as an immutable tag; `latest`, mutable aliases, and rebuilt images are not
-release inputs. Registry immutable-tag enforcement is required. Documentation
-and other non-impacting commits do not rebuild images.
+as their tag; `latest`, mutable aliases, and rebuilt images are not release
+inputs. Documentation and other non-impacting commits do not rebuild images.
+
+### Tag mutability
+
+Neither registry enables Artifact Registry's `--immutable-tags`, and that is
+deliberate rather than an oversight. That setting also blocks deletion of
+tagged images, which would break the cleanup policies both repositories rely
+on and would make release tags permanent once the planned `v*` scheme exists.
+
+A commit-SHA tag is therefore movable in principle. What stops a moved tag from
+reaching a deployment is attestation, not the registry: a re-pointed tag
+resolves to a digest with no valid provenance for that commit, and the resolver
+fails closed. Attestation is the single control here. Do not weaken it on the
+assumption that registry immutability is also holding the line, and do not
+enable immutable tags without first redesigning retention.
 
 The checked-in target catalog at `.github/scripts/release/targets.json` is the
 single source for the three release targets and their deployment order. The
@@ -167,7 +180,7 @@ compatible candidate is found in that window, publish a new release-impacting
 candidate rather than relying on an unbounded registry scan.
 
 CI pushes each image to a run-scoped staging tag, resolves and attests its exact
-digest, verifies the attestation, and only then adds the immutable SHA tag. A
+digest, verifies the attestation, and only then adds the SHA tag. A
 release resolves the selected candidate's three SHA tags once and writes a
 run-local JSON bundle:
 
@@ -198,8 +211,8 @@ the workflow execute only current protected automation (`CONTROL_SHA`) and walk
 first-parent history to select the newest ancestor with all three complete,
 attested candidate images (`RELEASE_SHA`). When `release_sha` is supplied, the
 resolver expands it to the full SHA, selects that commit directly, still
-requires complete immutable images and valid attestations, and skips the
-impact-path freshness check.
+requires a complete set of digest-pinned images and valid attestations, and
+skips the impact-path freshness check.
 
 An abbreviation is expanded with `git rev-parse --verify`, which rejects both
 unknown and ambiguous prefixes, so widening the accepted input does not widen
@@ -258,11 +271,15 @@ release that has already been replaced cannot be promoted.
 
 If a candidate SHA tag exists but its attestation is missing or invalid, CI
 fails closed and never re-attests the existing digest. Do not rerun the failed
-candidate workflow. Because Artifact Registry immutable tags may not be removed,
-the standard recovery is to quarantine the affected SHA and publish a new
-release-impacting commit; CI must create a new SHA tag and verify its attestation
-before release. If an old tag must be removed, use an explicitly approved
-registry-admin break-glass procedure. Do not manually attest an unknown image.
+candidate workflow. The standard recovery is to quarantine the affected SHA and
+publish a new release-impacting commit; CI must create a new SHA tag and verify
+its attestation before release.
+
+Removing the bad tag instead is possible but is not CI's to do: the candidate
+identity holds `roles/artifactregistry.writer`, which grants
+`artifactregistry.tags.create` and `.update` but not `.delete`. Tag removal
+therefore requires a registry admin and is an explicitly approved break-glass
+procedure. Do not manually attest an unknown image.
 
 Release and operational workflows share the non-canceling
 `cloud-run-release` concurrency group across both environments. It covers
@@ -375,10 +392,12 @@ record this rollout before declaring readiness:
   check, because a historical workflow definition may not contain that check.
 - [ ] Candidate, release, operations, runtime, and scheduler identities exist
   with the scopes above.
-- [ ] Both Artifact Registry repositories enforce immutable tags. Commit-SHA
-  tags are retained; staging-tag deletion is best-effort and immutable-tag
-  repositories may retain stale staging tags for approved registry retention
-  or admin cleanup.
+- [ ] Neither Artifact Registry repository enables immutable tags, and the
+  posture in "Tag mutability" above still holds. Staging-tag deletion is
+  best-effort and currently always fails, because the candidate identity has no
+  `artifactregistry.tags.delete`; a stale staging tag disappears with its image
+  version when the repository cleanup policy removes it, so the accumulation is
+  bounded by that policy rather than unbounded.
 - [ ] Required Google APIs are enabled and all three resources implement the
   `release-sha` label contract.
 - [ ] A documentation-only commit after a verified candidate promotes the


### PR DESCRIPTION
Follow-up to #145. Verifying that PR's first real candidate publish turned up
two documentation claims that do not hold, and one step that has never worked.
No functional behaviour changes; registry configuration is untouched.

## Immutable tags are not enabled, and should stay that way

`operations.md` said "Registry immutable-tag enforcement is required." Checked:

```
dev  radar → dockerConfig: null
prod radar → dockerConfig: {}
```

Neither enables it. Same shape as the `prevent_self_review` correction in #145:
a control the document treats as present is absent, and reasoning had already
been built on top of it.

Leaving it off is correct rather than a gap. `--immutable-tags` also blocks
deletion of tagged images, which would break the `olderThan` cleanup policies
both repositories run, and would make the planned `v*` release tags permanent
once that scheme lands. There is now a **Tag mutability** section saying this,
and saying plainly that **attestation is the single control** that rejects a
moved tag — so nobody weakens it believing the registry is also holding that
line.

## ADR 0001 needed the same correction

Its second reason claimed an interrupted publish bricks a commit *permanently*,
because an immutable tag cannot be removed. With mutable tags the commit is
recoverable — just not by CI. `roles/artifactregistry.writer` grants
`artifactregistry.tags.create` and `.update` but **not** `.delete`, so recovery
becomes a registry-admin break-glass action instead of an automatic retry.

Weaker than the original claim, and still enough to justify the staging step —
which is the thing that ADR exists to stop someone from removing. Consequences
now also record what enabling immutable tags later would cost.

## The staging-tag deletion is removed, not fixed

The first commit here corrected the warning text on that call, which blamed
immutable-tag retention for a failure that is really the missing `.delete`
permission. That was treating the symptom. The second commit removes the call.

It has never succeeded — 45 staging tags survive, the oldest from runs
predating this automation, so this is not a regression from #145 (the code
there was byte-identical apart from `echo` → `printf`). Every candidate publish
emitted one warning per target, which is how a repository teaches its
maintainer to stop reading warnings.

Nothing needed it. A staging tag aliases a digest that by that point already
carries its SHA tag: no extra storage, never consulted by the resolver, and it
disappears with its image version under the cleanup policy. Retention was
already doing the cleanup.

Granting the permission is the alternative and is worse — it widens a public
repository's long-lived static key from "can publish" to "can unpublish". The
code comment and the docs record that as a deliberate choice, plus the one
condition that would make it worth revisiting: retention changing to keep
versions indefinitely, which the planned `v*` tags would do for the versions
they mark.

## Verification

`release_test.sh` passes. The registry and IAM facts above were read with
read-only `gcloud describe` / `iam roles describe` calls.