### PR TITLE
refactor: stop attempting a staging-tag deletion that cannot succeed

### DIFF
--- a/.github/scripts/release/release.sh
+++ b/.github/scripts/release/release.sh
@@ -249,10 +249,11 @@ check_error_contract() {
 # Candidate publication
 # ---------------------------------------------------------------------------
 
-# Build to a run-scoped staging tag first. The immutable SHA tag is added only
-# after the digest has been attested and that attestation verified, because an
-# immutable tag cannot be removed: publishing it before attestation would turn
-# any interruption into a permanently unreleasable commit.
+# Build to a run-scoped staging tag first. The SHA tag is added only after the
+# digest has been attested and that attestation verified, because CI cannot
+# repair a SHA tag it published early: the release path refuses to re-attest an
+# existing digest, and removing the tag needs a permission CI does not hold.
+# See docs/adr/0001-attested-candidate-images.md.
 stage_candidate() {
   required OWNER TARGET RELEASE_SHA REGISTRY PROJECT_ID
   is_sha "${RELEASE_SHA}" || die 'invalid RELEASE_SHA'
@@ -309,8 +310,8 @@ stage_candidate() {
   } >> "${GITHUB_OUTPUT:-/dev/stdout}"
 }
 
-# Add the immutable SHA tag to the already attested digest, prove the tag
-# resolves to exactly that digest, then drop the staging tag.
+# Add the SHA tag to the already attested digest and prove the tag resolves to
+# exactly that digest.
 finalize_candidate() {
   required OWNER TARGET RELEASE_SHA REGISTRY PROJECT_ID STAGED_DIGEST NEEDS_FINALIZE
   local owner expected_base final_ref final_digest
@@ -325,18 +326,12 @@ finalize_candidate() {
   final_digest=$(resolved_digest "${final_ref}" "${PROJECT_ID}" "${expected_base}")
   [ "${final_digest##*@}" = "${STAGED_DIGEST}" ] \
     || integrity_die "final candidate tag for ${TARGET} does not equal the attested digest"
-  if [ -n "${STAGING_REF:-}" ]; then
-    # Expected to fail today: roles/artifactregistry.writer grants
-    # artifactregistry.tags.create and .update but not .delete, so the candidate
-    # identity cannot remove its own staging tag. The tag is an alias for a
-    # digest that already carries its SHA tag, so it costs no extra storage and
-    # is not a release input; it disappears with its image version when the
-    # repository cleanup policy removes it. Left as a warning rather than a
-    # failure because the candidate is already published and verified by here.
-    gcloud artifacts docker tags delete "${STAGING_REF}" \
-      --project="${PROJECT_ID}" --quiet \
-      || printf '::warning::Could not delete staging tag %s; the candidate identity has no artifactregistry.tags.delete. The tag expires with its image version.\n' "${STAGING_REF}"
-  fi
+  # The staging tag is deliberately left in place. It aliases a digest that now
+  # carries its SHA tag, so it occupies no extra storage, is never a release
+  # input, and expires with its image version under the repository cleanup
+  # policy. Deleting it would need artifactregistry.tags.delete, which the
+  # candidate identity does not hold and should not be given: that widens a
+  # public repository's long-lived key from "can publish" to "can unpublish".
   {
     echo '## Candidate image'
     echo

--- a/docs/adr/0001-attested-candidate-images.md
+++ b/docs/adr/0001-attested-candidate-images.md
@@ -2,7 +2,9 @@
 
 CI builds each candidate image to a run-scoped staging tag, resolves its exact
 digest, attests that digest, verifies the attestation, and only then adds the
-`:<commit-sha>` tag and deletes the staging tag. The obvious
+`:<commit-sha>` tag. The staging tag is then left to expire with its image
+version rather than deleted, because deleting it needs a permission the
+candidate identity deliberately does not hold. The obvious
 alternative — build and push straight to the SHA tag, then attest — is roughly
 twenty lines shorter, and it is what a reader will be tempted to collapse this
 back into.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -180,9 +180,10 @@ compatible candidate is found in that window, publish a new release-impacting
 candidate rather than relying on an unbounded registry scan.
 
 CI pushes each image to a run-scoped staging tag, resolves and attests its exact
-digest, verifies the attestation, and only then adds the SHA tag. A
-release resolves the selected candidate's three SHA tags once and writes a
-run-local JSON bundle:
+digest, verifies the attestation, and only then adds the SHA tag. The staging
+tag is left in place afterwards; it aliases the same digest, is never a release
+input, and expires with its image version. A release resolves the selected
+candidate's three SHA tags once and writes a run-local JSON bundle:
 
 ```json
 {
@@ -393,11 +394,10 @@ record this rollout before declaring readiness:
 - [ ] Candidate, release, operations, runtime, and scheduler identities exist
   with the scopes above.
 - [ ] Neither Artifact Registry repository enables immutable tags, and the
-  posture in "Tag mutability" above still holds. Staging-tag deletion is
-  best-effort and currently always fails, because the candidate identity has no
-  `artifactregistry.tags.delete`; a stale staging tag disappears with its image
-  version when the repository cleanup policy removes it, so the accumulation is
-  bounded by that policy rather than unbounded.
+  posture in "Tag mutability" above still holds. Staging tags are never
+  deleted: they alias a digest that already carries its SHA tag and expire with
+  their image version, so the accumulation is bounded by the cleanup policy. If
+  retention is ever changed to keep versions indefinitely, revisit this.
 - [ ] Required Google APIs are enabled and all three resources implement the
   `release-sha` label contract.
 - [ ] A documentation-only commit after a verified candidate promotes the


### PR DESCRIPTION
Follow-up to #146, which corrected this call's warning text. That was the wrong
fix — the call itself should not exist. (It was meant to be part of #146 but a
GitHub sync lag left it out of that PR's head before it merged.)

## Why remove it rather than fix it

`roles/artifactregistry.writer` grants `artifactregistry.tags.create` and
`.update` but **not** `.delete`, so the candidate identity has never been able
to remove its own staging tag. 45 of them survive, the oldest from runs
predating this automation. Every candidate publish emitted one warning per
target — which is how a repository teaches its maintainer to stop reading
warnings.

Nothing needed the deletion. By the time it runs, the staging tag aliases a
digest that already carries its SHA tag, so it:

- occupies no extra storage (Artifact Registry bills per version, not per tag)
- is never consulted by the resolver, which looks up `<base>:<sha>` only
- disappears with its image version when the cleanup policy removes it

Retention was already doing the cleanup. The step was pure dead weight.

## Why not just grant the permission

It widens a public repository's long-lived static service-account key from
"can publish" to "can unpublish". Not worth it for tidiness, and the surface
should be reconsidered as part of the WIF migration rather than before it.

## What replaces it

A comment recording the choice, the reasoning, and the one condition that would
make it worth revisiting: retention changing to keep versions indefinitely —
which the planned `v*` release tags will do for the versions they mark. The
same condition is noted in `operations.md`.

Also drops the stale "immutable" wording from two `release.sh` comments that
#146 corrected in the documentation but missed in the code.

## Verification

`release_test.sh` passes. No functional change to what gets published: the
staging tag was already surviving every run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that staging tags remain available after candidate image publication.
  - Documented that staging tags expire through standard repository cleanup.
  - Updated release guidance to reflect that finalization publishes and verifies the SHA tag without deleting staging tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->